### PR TITLE
Fix for ArgumentException when scrolling

### DIFF
--- a/ReoGrid/Views/NormalViewportController.cs
+++ b/ReoGrid/Views/NormalViewportController.cs
@@ -1079,7 +1079,7 @@ namespace unvell.ReoGrid.Views
 			}
 
 			int maxHorizontal = (int)(Math.Round(width + this.mainViewport.Left));
-			int maxVertical = (int)(Math.Round(height + this.mainViewport.Top));
+			int maxVertical = Math.Max(0, (int)(Math.Round(height + this.mainViewport.Top)));
 
 #if WINFORM || ANDROID
 			int offHor = maxHorizontal - this.scrollHorMax;


### PR DESCRIPTION
If the number of rows only fill very little space vertically and the scale is smaller than 1, "height" and thus "maxVertical" can become negative and then result in an execption when scrolling.

Example:
worksheet.rows[worksheet.rows.Count - 1].Bottom = 129
mainViewport.Height = 1054
scale = 0.75
=> height = -221.333328