### PR TITLE
Fix/selection moved backward event should be fired

### DIFF
--- a/ReoGrid/Core/Worksheet/Selection.cs
+++ b/ReoGrid/Core/Worksheet/Selection.cs
@@ -1125,8 +1125,8 @@ namespace unvell.ReoGrid
 		{
 			if (SelectionMovedBackward != null)
 			{
-				var arg = new SelectionMoveForwardEventArgs();
-				SelectionMovedForward(this, arg);
+				var arg = new SelectionMovedBackwardEventArgs();
+				SelectionMovedBackward(this, arg);
 				if (arg.IsCancelled)
 				{
 					return;

--- a/ReoGrid/Core/Worksheet/Selection.cs
+++ b/ReoGrid/Core/Worksheet/Selection.cs
@@ -1482,7 +1482,7 @@ namespace unvell.ReoGrid
 		/// <summary>
 		/// Event raised when focus-selection move to previous position
 		/// </summary>
-		public event EventHandler<SelectionMoveForwardEventArgs> SelectionMovedBackward;
+		public event EventHandler<SelectionMovedBackwardEventArgs> SelectionMovedBackward;
 
 		#endregion // Events
 	}

--- a/ReoGrid/Core/Worksheet/Selection.cs
+++ b/ReoGrid/Core/Worksheet/Selection.cs
@@ -1062,7 +1062,7 @@ namespace unvell.ReoGrid
 		{
 			if (SelectionMovedForward != null)
 			{
-				var arg = new SelectionMoveForwardEventArgs();
+				var arg = new SelectionMovedForwardEventArgs();
 				SelectionMovedForward(this, arg);
 				if (arg.IsCancelled)
 				{
@@ -1477,7 +1477,7 @@ namespace unvell.ReoGrid
 		/// <summary>
 		/// Event raised when focus-selection move to next position
 		/// </summary>
-		public event EventHandler<SelectionMoveForwardEventArgs> SelectionMovedForward;
+		public event EventHandler<SelectionMovedForwardEventArgs> SelectionMovedForward;
 
 		/// <summary>
 		/// Event raised when focus-selection move to previous position

--- a/ReoGrid/EventArgs.cs
+++ b/ReoGrid/EventArgs.cs
@@ -871,7 +871,7 @@ namespace unvell.ReoGrid.Events
 	/// ReoGrid automatically move the selection to 'Right' or 'Down' according
 	/// to 'SelectionForwardDirection' property of control. 
 	/// </summary>
-	public class SelectionMoveForwardEventArgs : EventArgs
+	public class SelectionMovedForwardEventArgs : EventArgs
 	{
 		/// <summary>
 		/// Decide whether to cancel current operation
@@ -879,10 +879,9 @@ namespace unvell.ReoGrid.Events
 		public bool IsCancelled { get; set; }
 
 		/// <summary>
-		/// Create instance for SelectionMoveForwardEventArgs with specified 
-		/// position.
+		/// Create instance of SelectionMovedForwardEventArgs with specified position.
 		/// </summary>
-		public SelectionMoveForwardEventArgs()
+		public SelectionMovedForwardEventArgs()
 		{
 		}
 	}

--- a/ReoGrid/EventArgs.cs
+++ b/ReoGrid/EventArgs.cs
@@ -887,6 +887,26 @@ namespace unvell.ReoGrid.Events
 	}
 
 	/// <summary>
+	/// Event raised when selection moved to previous position. 
+	/// ReoGrid automatically move selection to left cell or above cell according
+	/// to <code>SelectionForwardDirection</code> property of worksheet. 
+	/// </summary>
+	public class SelectionMovedBackwardEventArgs : EventArgs
+	{
+		/// <summary>
+		/// Decide whether to cancel current move operation.
+		/// </summary>
+		public bool IsCancelled { get; set; }
+
+		/// <summary>
+		/// Create instance of SelectionMovedBackwardEventArgs with specified position.
+		/// </summary>
+		public SelectionMovedBackwardEventArgs()
+		{
+		}
+	}
+
+	/// <summary>
 	/// Argument class for event of BeforeSelectionChange
 	/// </summary>
 	public class BeforeSelectionChangeEventArgs : EventArgs

--- a/ReoGrid/EventArgs.cs
+++ b/ReoGrid/EventArgs.cs
@@ -867,14 +867,14 @@ namespace unvell.ReoGrid.Events
 	#region Selection
 
 	/// <summary>
-	/// Event raised when selection will move to another position. 
-	/// ReoGrid automatically move the selection to 'Right' or 'Down' according
-	/// to 'SelectionForwardDirection' property of control. 
+	/// Event raised when selection moved to next position. 
+	/// ReoGrid automatically move selection to right cell or below cell according
+	/// to <code>SelectionForwardDirection</code> property of worksheet. 
 	/// </summary>
 	public class SelectionMovedForwardEventArgs : EventArgs
 	{
 		/// <summary>
-		/// Decide whether to cancel current operation
+		/// Decide whether to cancel current move operation.
 		/// </summary>
 		public bool IsCancelled { get; set; }
 


### PR DESCRIPTION
Fix the following problems:
- `SelectionMovedBackward` should be fired when focus cell moved to previous position
- `SelectionMovedBackwardEventArgs` class should be used when `SelectionMovedBackward` event fired