### PR TITLE
Refactored autofill serial to remove duplication and exclude autofilling to readonly cells

### DIFF
--- a/ReoGrid/Core/Data.cs
+++ b/ReoGrid/Core/Data.cs
@@ -96,6 +96,11 @@ namespace unvell.ReoGrid
 
             List<CellPosition> fromCells, toCells;
 
+            if (CheckRangeReadonly(toRange))
+            {
+                throw new RangeContainsReadonlyCellsException(toRange);
+            }
+
             if (fromRange.Col == toRange.Col && fromRange.Cols == toRange.Cols)
             {
                 for (int c = toRange.Col; c <= toRange.EndCol; c++)
@@ -166,11 +171,6 @@ namespace unvell.ReoGrid
                 var fromCell = Cells[fromCellPosition];
                 var toCellPosition = toCells[toCellIndex];
                 var toCell = Cells[toCellPosition];
-
-                if (toCell != null && toCell.IsReadOnly)
-                {
-                    continue;
-                }
 
                 if (fromCell == null)
                 {

--- a/ReoGrid/Core/Data.cs
+++ b/ReoGrid/Core/Data.cs
@@ -1,7 +1,7 @@
 ﻿/*****************************************************************************
- * 
+ *
  * ReoGrid - .NET Spreadsheet Control
- * 
+ *
  * http://reogrid.net/
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY
@@ -13,7 +13,7 @@
  *
  * Copyright (c) 2012-2016 Jing <lujing at unvell.com>
  * Copyright (c) 2012-2016 unvell.com, all rights reserved.
- * 
+ *
  ****************************************************************************/
 
 #if FORMULA
@@ -103,7 +103,7 @@ namespace unvell.ReoGrid
 
             if (fromRange.Col == toRange.Col && fromRange.Cols == toRange.Cols)
             {
-                for (int c = toRange.Col; c <= toRange.EndCol; c++)
+                for (var c = toRange.Col; c <= toRange.EndCol; c++)
                 {
                     fromCells = GetColumnCellPositionsFromRange(fromRange, c);
                     toCells = GetColumnCellPositionsFromRange(toRange, c);
@@ -112,7 +112,7 @@ namespace unvell.ReoGrid
             }
             else if (fromRange.Row == toRange.Row && fromRange.Rows == toRange.Rows)
             {
-                for (int r = toRange.Row; r <= toRange.EndRow; r++)
+                for (var r = toRange.Row; r <= toRange.EndRow; r++)
                 {
                     fromCells = GetRowCellPositionsFromRange(fromRange, r);
                     toCells = GetRowCellPositionsFromRange(toRange, r);
@@ -162,6 +162,11 @@ namespace unvell.ReoGrid
 
         private void AutoFillSerialCells(List<CellPosition> fromCells, List<CellPosition> toCells)
         {
+            if (!fromCells.Any() || !toCells.Any())
+            {
+                return;
+            }
+
             double diff = GetCellsDifference(fromCells);
 
             for (var toCellIndex = 0; toCellIndex < toCells.Count; toCellIndex++)
@@ -225,7 +230,7 @@ namespace unvell.ReoGrid
                     }
                 }
             }
-            
+
             return diff;
         }
     }

--- a/ReoGrid/Core/Data.cs
+++ b/ReoGrid/Core/Data.cs
@@ -167,6 +167,11 @@ namespace unvell.ReoGrid
                 var toCellPosition = toCells[toCellIndex];
                 var toCell = Cells[toCellPosition];
 
+                if (toCell != null && toCell.IsReadOnly)
+                {
+                    continue;
+                }
+
                 if (fromCell == null)
                 {
                     continue;

--- a/ReoGrid/Core/Range.cs
+++ b/ReoGrid/Core/Range.cs
@@ -840,12 +840,12 @@ namespace unvell.ReoGrid
 
 			if (CheckRangeReadonly(fromRange))
 			{
-				throw new RangeContainsReadonlyCellsException(fromRange, "Operation cannot be performed since target range contains read-only cells.");
+				throw new RangeContainsReadonlyCellsException(fromRange);
 			}
 
 			if (CheckRangeReadonly(toRange))
 			{
-				throw new RangeContainsReadonlyCellsException(fromRange, "Operation cannot be performed since target range contains read-only cells.");
+				throw new RangeContainsReadonlyCellsException(fromRange);
 			}
 
 			var bcmrearg = new BeforeCopyOrMoveRangeEventArgs(fromRange, toRange);

--- a/ReoGrid/Exceptions.cs
+++ b/ReoGrid/Exceptions.cs
@@ -543,15 +543,26 @@ namespace unvell.ReoGrid
 		/// </summary>
 		public RangePosition Range { get; set; }
 
-		/// <summary>
-		/// Create exception with additional message.
-		/// </summary>
-		/// <param name="msg">The additional message to describe this exception.</param>
-		public RangeContainsReadonlyCellsException(RangePosition range, string msg)
+        /// <summary>
+        /// Create exception with the default message.
+        /// </summary>
+        /// <param name="range">Range that operation applied on.</param>
+        public RangeContainsReadonlyCellsException(RangePosition range)
+            : this(range, "Operation cannot be performed since target range contains read-only cells.")
+        {
+        }
+
+        /// <summary>
+        /// Create exception with additional message.
+        /// </summary>
+        /// <param name="range">Range that operation applied on.</param>
+        /// <param name="msg">The additional message to describe this exception.</param>
+        public RangeContainsReadonlyCellsException(RangePosition range, string msg)
 			: base(msg)
 		{
+		    Range = range;
 		}
-	}
+    }
 
 	/// <summary>
 	/// Exception will be thrown when the cell body cannot be created for a cell automatically.

--- a/ReoGrid/Views/CellsViewport.cs
+++ b/ReoGrid/Views/CellsViewport.cs
@@ -1683,12 +1683,12 @@ namespace unvell.ReoGrid.Views
 						{
 							if (this.sheet.CheckRangeReadonly(fromRange))
 							{
-								throw new RangeContainsReadonlyCellsException(fromRange, "Operation cannot be performed since target range contains read-only cells.");
+								throw new RangeContainsReadonlyCellsException(fromRange);
 							}
 
 							if (this.sheet.CheckRangeReadonly(toRange))
 							{
-								throw new RangeContainsReadonlyCellsException(toRange, "Operation cannot be performed since target range contains read-only cells.");
+								throw new RangeContainsReadonlyCellsException(toRange);
 							}
 
 							BaseWorksheetAction action;


### PR DESCRIPTION
Hi, 

I encountered an issue when autofill would overlap readonly cells, and just wanted to quickly fix it. Then I learned of some duplication in this bit of code, and quite  huge, hard to comprehend method. So I refactored that first. These commits are the result.

After testing I discovered a small functional change as well that had snuck in. When autofilling on merged cells it used to increment with the amount of merged cells, instead of treating them as one cell. I realised it actually makes more sense to me to count a merged cell as one cell, so I delibirately did not fix it.

Summary:
- Cleaner code for AutoFill
- AutoFill over merged cells counts better
- AutoFill over readonly cells will not fill the content of the cell.

I hope you like it. :-)