### PR TITLE
Disable paste to read-only cells

### DIFF
--- a/Editor/ReoGridEditor.cs
+++ b/Editor/ReoGridEditor.cs
@@ -683,6 +683,11 @@ namespace unvell.ReoGrid.Editor
 					MessageBox.Show(this, LangResource.Msg_Range_Intersection_Exception,
 						"ReoGrid Editor", MessageBoxButtons.OK, MessageBoxIcon.Stop);
 				}
+				else if (e.Exception is OperationOnReadonlyCellException)
+				{
+					MessageBox.Show(this, LangResource.Msg_Operation_Aborted,
+						"ReoGrid Editor", MessageBoxButtons.OK, MessageBoxIcon.Stop);
+				}
 			};
 
 			this.grid.CurrentWorksheetChanged += (s, e) =>

--- a/ReoGrid/Core/Clipboard.cs
+++ b/ReoGrid/Core/Clipboard.cs
@@ -263,7 +263,7 @@ namespace unvell.ReoGrid
 							clipboardText = data.GetText();
 						}
 					}
-					
+
 #elif ANDROID
 
 #endif // WINFORM || WPF
@@ -303,6 +303,13 @@ namespace unvell.ReoGrid
 						{
 							// TODO: paste range overflow
 							// need to notify user-code to handle this 
+							return false;
+						}
+
+						// check whether the range to be pasted contains readonly cell
+						if (this.CheckRangeReadonly(targetRange))
+						{
+							this.NotifyExceptionHappen(new OperationOnReadonlyCellException("specified range contains readonly cell"));
 							return false;
 						}
 


### PR DESCRIPTION
- check whether paste range contains read-only cell
- abort the paste operation if paste range contains read-only cell
- report an exception to instance of workbook if user attempts to do action like this
- exception class `OperationOnReadonlyCellException`

fixes #32