### PR TITLE
GetDefaultDataSerialFillColor error when the parameter index>=default…

### DIFF
--- a/ReoGrid/Chart/Utility.cs
+++ b/ReoGrid/Chart/Utility.cs
@@ -66,7 +66,7 @@ namespace unvell.ReoGrid.Chart
 			{
 				if (index < MaxDataSerials)
 				{
-					for (int i = defaultDataSerialColors.Count; i < index; i++)
+					for (int i = defaultDataSerialColors.Count; i <= index; i++)
 					{
 						defaultDataSerialColors.Add(SolidColor.Randomly());
 					}


### PR DESCRIPTION
Logical issue  for the function GetDefaultDataSerialFillColor