### PR TITLE
AutoFillSerial support for text.

### DIFF
--- a/ReoGrid/Core/AutoFillSerial/AutoFillSection.cs
+++ b/ReoGrid/Core/AutoFillSerial/AutoFillSection.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace unvell.ReoGrid
+{
+    public class AutoFillSection
+    {
+        private readonly List<IAutoFillSectionEntry> entries = new List<IAutoFillSectionEntry>();
+
+        public AutoFillSection(IAutoFillSectionEntry entry)
+        {
+            entries.Add(entry);
+        }
+
+        public bool TryAdd(IAutoFillSectionEntry entry)
+        {
+            if (entries.First().IsSequenceOf(entry))
+            {
+                entries.Add(entry);
+                return true;
+            }
+
+            return false;
+        }
+
+        public object[] GetValues(int iteration)
+        {
+            var baseValue = entries.First().Value;
+            var incrementPerIteration = entries.Last().GetIncrementPerIteration(baseValue, entries.Count);
+
+            return entries.Select(entry => entry.GetIterationValue(baseValue, incrementPerIteration, iteration)).ToArray();
+        }
+    }
+}

--- a/ReoGrid/Core/AutoFillSerial/AutoFillSectionEntryFactory.cs
+++ b/ReoGrid/Core/AutoFillSerial/AutoFillSectionEntryFactory.cs
@@ -1,0 +1,23 @@
+﻿using unvell.ReoGrid.Utility;
+
+namespace unvell.ReoGrid
+{
+    public static class AutoFillSectionEntryFactory
+    {
+        public static IAutoFillSectionEntry Create(object value)
+        {
+            if (value == null)
+            {
+                return new NullAutoFillSectionEntry();
+            }
+
+            double number;
+            if (CellUtility.TryGetNumberData(value, out number))
+            {
+                return new NumericalAutoFillSectionEntry(number);
+            }
+
+            return new TextAutoFillSectionEntry(value.ToString());
+        }
+    }
+}

--- a/ReoGrid/Core/AutoFillSerial/AutoFillSequence.cs
+++ b/ReoGrid/Core/AutoFillSerial/AutoFillSequence.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace unvell.ReoGrid
+{
+    public class AutoFillSequence
+    {
+        private readonly List<AutoFillSection> sections = new List<AutoFillSection>();
+
+        public AutoFillSequence(IList<object> values)
+        {
+            if (values == null || values.Count == 0)
+            {
+                throw new ArgumentException("AutoFillSequence requires at least one value.");
+            }
+
+            var valueIndex = 0;
+
+            var entry = AutoFillSectionEntryFactory.Create(values[valueIndex++]);
+            var currentSection = new AutoFillSection(entry);
+            sections.Add(currentSection);
+
+            while (valueIndex < values.Count)
+            {
+                entry = AutoFillSectionEntryFactory.Create(values[valueIndex++]);
+                if (!currentSection.TryAdd(entry))
+                {
+                    currentSection = new AutoFillSection(entry);
+                    sections.Add(currentSection);
+                }
+            }
+        }
+
+        public object[] Extrapolate(int count)
+        {
+            List<object> result = new List<object>(count);
+
+            var iteration = 0;
+
+            while (result.Count < count)
+            {
+                // First iteration is the input values. So start iterating from 1.
+                iteration++;
+                foreach (var section in sections)
+                {
+                    var items = section.GetValues(iteration);
+                    result.AddRange(items.Take(count - result.Count));
+                }
+            }
+
+            return result.ToArray();
+        }
+    }
+}

--- a/ReoGrid/Core/AutoFillSerial/IAutoFillSectionEntry.cs
+++ b/ReoGrid/Core/AutoFillSerial/IAutoFillSectionEntry.cs
@@ -1,0 +1,13 @@
+﻿namespace unvell.ReoGrid
+{
+    public interface IAutoFillSectionEntry
+    {
+        object Value { get; }
+
+        bool IsSequenceOf(IAutoFillSectionEntry otherEntry);
+
+        object GetIterationValue(object baseValue, object incrementPerIteration, int iteration);
+
+        object GetIncrementPerIteration(object baseValue, int numberOfEntries);
+    }
+}

--- a/ReoGrid/Core/AutoFillSerial/NullAutoFillSectionEntry.cs
+++ b/ReoGrid/Core/AutoFillSerial/NullAutoFillSectionEntry.cs
@@ -1,0 +1,22 @@
+﻿namespace unvell.ReoGrid
+{
+    public class NullAutoFillSectionEntry : IAutoFillSectionEntry
+    {
+        public object Value { get; }
+
+        public bool IsSequenceOf(IAutoFillSectionEntry otherEntry)
+        {
+            return otherEntry is NullAutoFillSectionEntry;
+        }
+
+        public object GetIterationValue(object baseValue, object incrementPerIteration, int iteration)
+        {
+            return null;
+        }
+
+        public object GetIncrementPerIteration(object baseValue, int numberOfEntries)
+        {
+            return null;
+        }
+    }
+}

--- a/ReoGrid/Core/AutoFillSerial/NumericalAutoFillSectionEntry.cs
+++ b/ReoGrid/Core/AutoFillSerial/NumericalAutoFillSectionEntry.cs
@@ -1,0 +1,37 @@
+﻿namespace unvell.ReoGrid
+{
+    public class NumericalAutoFillSectionEntry : IAutoFillSectionEntry
+    {
+        public object Value { get; }
+
+        public NumericalAutoFillSectionEntry(double value)
+        {
+            Value = value;
+        }
+
+        public bool IsSequenceOf(IAutoFillSectionEntry otherEntry)
+        {
+            return otherEntry is NumericalAutoFillSectionEntry;
+        }
+
+        public object GetIterationValue(object baseValue, object incrementPerIteration, int iteration)
+        {
+            var diff = GetDifferenceToBaseValue(baseValue);
+            var incr = (double)incrementPerIteration;
+
+            return (double)baseValue + diff + incr * iteration;
+        }
+
+        public object GetIncrementPerIteration(object baseValue, int numberOfEntries)
+        {
+            return numberOfEntries > 1
+                ? (GetDifferenceToBaseValue(baseValue) / (numberOfEntries - 1)) * numberOfEntries
+                : 0;
+        }
+
+        private double GetDifferenceToBaseValue(object baseValue)
+        {
+            return (double)Value - (double)baseValue;
+        }
+    }
+}

--- a/ReoGrid/Core/AutoFillSerial/TextAutoFillSectionEntry.cs
+++ b/ReoGrid/Core/AutoFillSerial/TextAutoFillSectionEntry.cs
@@ -1,0 +1,81 @@
+﻿using System.Linq;
+
+namespace unvell.ReoGrid
+{
+    public class TextAutoFillSectionEntry : IAutoFillSectionEntry
+    {
+        public object Value { get; }
+
+        private string textLeftOfDigit = string.Empty;
+        private string textRightOfDigit = string.Empty;
+        private bool hasDigit;
+
+        public TextAutoFillSectionEntry(string value)
+        {
+            var digits = "0123456789".ToCharArray();
+
+            var indexOfFirstDigit = value.IndexOfAny(digits);
+
+            if (indexOfFirstDigit == -1)
+            {
+                textLeftOfDigit = value;
+            }
+            else
+            {
+                hasDigit = true;
+                if (indexOfFirstDigit > 0)
+                {
+                    textLeftOfDigit = value.Substring(0, indexOfFirstDigit);
+                    value = value.Substring(indexOfFirstDigit);
+                }
+
+                var numberSequence = value.TakeWhile(c => digits.Contains(c)).ToArray();
+                textRightOfDigit = value.Substring(numberSequence.Length);
+
+                Value = double.Parse(new string(numberSequence));
+            }
+        }
+
+        public bool IsSequenceOf(IAutoFillSectionEntry otherEntry)
+        {
+            var otherTextEntry = otherEntry as TextAutoFillSectionEntry;
+            if (otherTextEntry == null)
+            {
+                return false;
+            }
+
+            return textLeftOfDigit.Equals(otherTextEntry.textLeftOfDigit)
+                   && textRightOfDigit.Equals(otherTextEntry.textRightOfDigit)
+                   && hasDigit == otherTextEntry.hasDigit;
+        }
+
+        public object GetIterationValue(object baseValue, object incrementPerIteration, int iteration)
+        {
+            var digitText = string.Empty;
+
+            if (hasDigit)
+            {
+                var diff = GetDifferenceToBaseValue(baseValue);
+                var incr = (double) incrementPerIteration;
+
+                digitText = ((double) baseValue + diff + incr * iteration).ToString();
+            }
+
+            return $"{textLeftOfDigit}{digitText}{textRightOfDigit}";
+        }
+
+        public object GetIncrementPerIteration(object baseValue, int numberOfEntries)
+        {
+            return numberOfEntries > 1 && hasDigit
+                ? (GetDifferenceToBaseValue(baseValue) / (numberOfEntries - 1)) * numberOfEntries
+                : 0;
+        }
+
+        private double GetDifferenceToBaseValue(object baseValue)
+        {
+            return hasDigit
+                ? (double)Value - (double)baseValue
+                : 0;
+        }
+    }
+}

--- a/ReoGrid/ReoGrid.csproj
+++ b/ReoGrid/ReoGrid.csproj
@@ -259,17 +259,24 @@
     <Compile Include="Chart\Title.cs" />
     <Compile Include="Chart\Utility.cs" />
     <Compile Include="Control\Interfaces.cs" />
+    <Compile Include="Core\AutoFillSerial\AutoFillSectionEntryFactory.cs" />
+    <Compile Include="Core\AutoFillSerial\AutoFillSection.cs" />
+    <Compile Include="Core\AutoFillSerial\AutoFillSequence.cs" />
     <Compile Include="Core\Cell\Merge.cs" />
     <Compile Include="Core\Cell\Text.cs" />
     <Compile Include="Core\CSV.cs" />
     <Compile Include="Core\Data.cs" />
     <Compile Include="Core\Drawing.cs" />
     <Compile Include="Core\FilterSort.cs" />
+    <Compile Include="Core\AutoFillSerial\NumericalAutoFillSectionEntry.cs" />
+    <Compile Include="Core\AutoFillSerial\IAutoFillSectionEntry.cs" />
+    <Compile Include="Core\AutoFillSerial\NullAutoFillSectionEntry.cs" />
     <Compile Include="Core\Range\HighlightRange.cs" />
     <Compile Include="Core\Range\Merge.cs" />
     <Compile Include="Core\Position.cs" />
     <Compile Include="Core\Range\NamedRange.cs" />
     <Compile Include="Core\Range\ReferenceRange.cs" />
+    <Compile Include="Core\AutoFillSerial\TextAutoFillSectionEntry.cs" />
     <Compile Include="Core\ViewControl.cs" />
     <Compile Include="Core\Workbook\Appearance.cs" />
     <Compile Include="Core\Workbook\Languages.cs" />
@@ -327,7 +334,9 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
-    <Compile Include="Test\RichTextTestForm.cs" />
+    <Compile Include="Test\RichTextTestForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="Test\RichTextTestForm.Designer.cs">
       <DependentUpon>RichTextTestForm.cs</DependentUpon>
     </Compile>
@@ -399,7 +408,9 @@
     <Compile Include="Views\CellsViewport.cs" />
     <Compile Include="WinForm\Graphics.cs" />
     <Compile Include="Views\NormalViewportController.cs" />
-    <Compile Include="WinForm\FormulaParserForm.cs" />
+    <Compile Include="WinForm\FormulaParserForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="WinForm\FormulaParserForm.designer.cs">
       <DependentUpon>FormulaParserForm.cs</DependentUpon>
     </Compile>

--- a/TestCase/TestsNUnit/AutoFillSerialTests.cs
+++ b/TestCase/TestsNUnit/AutoFillSerialTests.cs
@@ -1,0 +1,254 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+// Name conflict with the Unvell TestManager and Nunit
+using TestC = NUnit.Framework.TestCaseAttribute;
+
+namespace unvell.ReoGrid.Tests.TestsNUnit
+{
+    [TestFixture]
+    public class AutoFillSerialTests
+    {
+        private ReoGridControl control;
+        private Worksheet sheet;
+
+        [SetUp]
+        public void Setup()
+        {
+            control = new ReoGridControl();
+            sheet = control.Worksheets[0];
+        }
+
+        [Test]
+        public void AutoFillSerial_Horizontol()
+        {
+            // Arrange
+            sheet[1, 1] = 1;
+            sheet[1, 2] = 2;
+
+            // Act
+            sheet.AutoFillSerial(RangePosition.FromCellPosition(1, 1, 1, 2), RangePosition.FromCellPosition(1, 3, 1, 4));
+
+            // Assert
+            Assert.AreEqual(3, sheet[1, 3]);
+            Assert.AreEqual(4, sheet[1, 4]);
+        }
+
+        [Test]
+        public void AutoFillSerial_Vertical()
+        {
+            // Arrange
+            sheet[1, 1] = 1;
+            sheet[2, 1] = 2;
+
+            // Act
+            sheet.AutoFillSerial(RangePosition.FromCellPosition(1, 1, 2, 1), RangePosition.FromCellPosition(3, 1, 4, 1));
+
+            // Assert
+            Assert.AreEqual(3, sheet[3, 1]);
+            Assert.AreEqual(4, sheet[4, 1]);
+        }
+
+        [TestC("A1:A2", "A3:B3")]
+        [TestC("A1:B1", "C1:D2")]
+        public void AutoFillSerial_TargetRangeDoesNotHaveMathingRowsOrColumns_ThrowsInvalidOperationException(string fromRange, string toRange)
+        {
+            // Arrange
+            sheet[fromRange] = 1;
+
+            // Act
+            var testDelegate = new TestDelegate(() => sheet.AutoFillSerial(fromRange, toRange));
+
+            // Assert
+            Assert.Throws<InvalidOperationException>(testDelegate);
+        }
+
+        [TestC("A1:C3", "A2:C5")]
+        [TestC("A1:C3", "B1:F3")]
+        public void AutoFillSerial_TargetRangeIntersectsFromRange_ThrowsArgumentException(string fromRange, string toRange)
+        {
+            // Arrange
+            sheet[fromRange] = 1;
+
+            // Act
+            var testDelegate = new TestDelegate(() => sheet.AutoFillSerial(fromRange, toRange));
+
+            // Assert
+            Assert.Throws<ArgumentException>(testDelegate);
+        }
+
+        public static IEnumerable<TestCaseData> AutoFillSerialInputOutputTestDataProvider
+        {
+            get
+            {
+                yield return new TestCaseData(
+                        new object[] { 1 },
+                        new object[] { 1, 1, 1 })
+                { TestName = "Single int" };
+
+                yield return new TestCaseData(
+                    new object[] { 1, 2, 3 },
+                    new object[] { 4, 5, 6 })
+                { TestName = "Input of linear ints" };
+
+                yield return new TestCaseData(
+                        new object[] { 1.1, 1.2, 1.3 },
+                        new object[] { 1.4, 1.5, 1.6 })
+                { TestName = "Input linear doubles" };
+
+                yield return new TestCaseData(
+                        new object[] { "1", "2", "3" },
+                        new object[] { 4, 5, 6 })
+                { TestName = "Strings in, ints out" };
+
+                yield return new TestCaseData(
+                        new object[] { 1, 5, 3 },
+                        new object[] { 4, 8, 6, 7, 11, 9 })
+                { TestName = "Non linear ints (1)" };
+
+                yield return new TestCaseData(
+                        new object[] { 1, 4, 2, 5, 3, 6 },
+                        new object[] { 7, 10, 8, 11, 9, 12, 13, 16, 14 })
+                { TestName = "Non linear ints (2)" };
+
+                yield return new TestCaseData(
+                        new object[] { 1, 2, null },
+                        new object[] { 3, 4, null, 5, 6 })
+                { TestName = "Empty cell" };
+
+                yield return new TestCaseData(
+                        new object[] { "Text" },
+                        new object[] { "Text", "Text", "Text" })
+                { TestName = "Text" };
+
+                yield return new TestCaseData(
+                        new object[] { "Text 1" },
+                        new object[] { "Text 1", "Text 1", "Text 1" })
+                { TestName = "Text 1" };
+
+                yield return new TestCaseData(
+                        new object[] { "Text 1", "Text 2" },
+                        new object[] { "Text 3", "Text 4", "Text 5" })
+                { TestName = "Text 1, Text 2" };
+
+                yield return new TestCaseData(
+                        new object[] { "Text 1", "Text 6", "Text 5" },
+                        new object[] { "Text 7", "Text 12", "Text 11" })
+                { TestName = "Text 1, Text 5, Text 6" };
+
+                yield return new TestCaseData(
+                        new object[] { "1 Text", "4 Text" },
+                        new object[] { "7 Text", "10 Text" })
+                { TestName = "1 Text, 4 Text" };
+
+                yield return new TestCaseData(
+                        new object[] { "1 Text 5", "4 Text 5" },
+                        new object[] { "7 Text 5", "10 Text 5" })
+                { TestName = "1 Text 5, 4 Text 5" };
+
+                yield return new TestCaseData(
+                        new object[] { "T3xt", "T2xt" },
+                        new object[] { "T1xt", "T0xt", "T-1xt" })
+                { TestName = "T3xt, T2xt" };
+
+                yield return new TestCaseData(
+                        new object[] { 1, "2", "MyText", "Up2", "Up3", "8Down", "7Down" },
+                        new object[] { 3, 4, "MyText", "Up4", "Up5", "6Down", "5Down", 5, 6, "MyText","Up6", "Up7", "4Down", "3Down" })
+                    { TestName = "Mixed mess" };
+            }
+        }
+
+        [TestCaseSource(nameof(AutoFillSerialInputOutputTestDataProvider))]
+        public void AutoFillSerial_InputData_ExpectedOutputData(object[] inputData, object[] outputData)
+        {
+            // Arrange
+            for (int r = 0; r < inputData.Length; r++)
+            {
+                sheet[r, 0] = inputData[r];
+            }
+
+            var outputRange = RangePosition.FromCellPosition(inputData.Length, 0, inputData.Length + outputData.Length - 1, 0);
+
+            // Act
+            sheet.AutoFillSerial(
+                RangePosition.FromCellPosition(0, 0, inputData.Length - 1, 0),
+                outputRange
+                );
+
+            // Assert
+            Console.WriteLine("Values in input range:");
+            inputData.ToList().ForEach(Console.WriteLine);
+            Console.WriteLine("Expected output:");
+            outputData.ToList().ForEach(Console.WriteLine);
+
+            Console.WriteLine("Actual output:");
+            sheet.IterateCells(outputRange, (r, c, cell) =>
+            {
+                Console.WriteLine(cell.Data);
+                return true;
+            });
+
+            var offset = inputData.Length;
+            for (var r = 0; r < outputData.Length; r++)
+            {
+                Assert.AreEqual(outputData[r], sheet[r + offset, 0]);
+            }
+        }
+
+        [Test]
+        public void AutoFillSerial_Formulas_IsAutoFilled()
+        {
+            // Arrange
+            sheet.Cells["B1"].Data = 30;
+            sheet.Cells["B2"].Data = 63;
+            sheet.Cells["B3"].Data = 2;
+            sheet.Cells["A1"].Formula = "B1";
+
+            // Act
+            sheet.AutoFillSerial("A1", "A2:A3");
+
+            // Assert
+            Assert.AreEqual(30, sheet["A1"]);
+            Assert.AreEqual(63, sheet["A2"]);
+            Assert.AreEqual(2, sheet["A3"]);
+
+            Assert.IsTrue(sheet.Cells["A2"].HasFormula);
+            Assert.IsTrue(sheet.Cells["A3"].HasFormula);
+            Assert.AreEqual("B2", sheet.Cells["A2"].Formula);
+            Assert.AreEqual("B3", sheet.Cells["A3"].Formula);
+        }
+
+        [Test]
+        public void AutoFillSerial_FormulasMixedWithRegularCells_IsAutoFilled()
+        {
+            // Arrange
+            sheet.Cells["B1"].Data = 30;
+            sheet.Cells["B2"].Data = 63;
+            sheet.Cells["B3"].Data = 2;
+            sheet.Cells["B4"].Data = 8;
+            sheet.Cells["B5"].Data = 102;
+            sheet.Cells["B6"].Data = 55;
+
+            sheet.Cells["A1"].Data = 1;
+            sheet.Cells["A2"].Formula = "B2";
+            sheet.Cells["A3"].Data = 3;
+
+            // Act
+            sheet.AutoFillSerial("A1:A3", "A4:A6");
+
+            // Assert
+            Assert.AreEqual(1, sheet["A1"]);
+            Assert.AreEqual(63, sheet["A2"]);
+            Assert.AreEqual(3, sheet["A3"]);
+            Assert.AreEqual(4, sheet["A4"]);
+            Assert.AreEqual(102, sheet["A5"]);
+            Assert.AreEqual(6, sheet["A6"]);
+
+            Assert.IsFalse(sheet.Cells["A4"].HasFormula);
+            Assert.IsTrue(sheet.Cells["A5"].HasFormula);
+            Assert.IsFalse(sheet.Cells["A6"].HasFormula);
+        }
+    }
+}

--- a/TestCase/packages.config
+++ b/TestCase/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.8.1" targetFramework="net35" />
+</packages>


### PR DESCRIPTION
Hi Jing, 

Here's the pull request for #61. Support for text-cells, yay! :-)

AutoFill behavior has slightly changed in this PR. This is intentional, as I believe it's for the better. Of course it's your project, so please review the new behavior and let me know if you agree with it or not. You can quickly view the "AutoFillSerialInputOutputTestDataProvider" method in the unit-test-class. There's a lot of I/O testing described in there.

Big picture of the solution:
1. There's an AutoFillSequence, which covers the entire selected range.
2. AutoFillSequence splits itself into AutoFillSections. Each section has its own diff-calculation and therefor it's own repeat pattern. AutoFillSection does no calculations itself. It just stores it.
3. The section is made up out of AutoFillSectionEntries, each representing a single cell's value. This is the one calculating the diff and extrapolation to other entries. Because of this, it should be relatively easy to add AutoFillSectionEntries for DateTime and other datatypes.

Future benefits:
It should be relatively easy to refactor this a bit more to support custom AutoFillSectionEntries. All that's needed is the ability to customize for the AutoFillSectionEntryFactory from externally. Then the user can add his own data types and extrapolation logic.

Notable Differences:
You may remember this remark in #61 
`[1],[4],[2],[5],[3],[6]. With an avarage increase of 1 per cell I would've expected: [4],[7],[5],[8],[6],[9]. But instead Reogrid produces: [9,625][12,625][10,625][13,625][11,625][14,625]. The pattern is there, but the calculation of the avarage increase per cell is bust.`

You can now see in the unit-test it produces "7, 10, 8, 11, 9, 12, 13, 16, 14".
Over a span of 6 cells, the value increased from 1 to 6, which avarages to 1-per-cell. The pattern then repeats after 6 cells. Meaning it starts with: 
<BaseValue (1)> + <AvgPerCell(1)> * <length of the pattern (6) = 7.
After that the new basevalue is 7, en the rest will be added/substracted based on the differences in the pattern.
So the comma-values is fixed. But repeats patterns, it does not continue patterns.

Another difference would be the workings of sections. Take for instance:
1, 2, null, 3, 4, null
You might expect it to continue as
5, 6, null, 7, 8, null
Instead, because the null is in the middle, it counts as 2 separate sections, which calculate it's diff and extrapolate independently. So it'll continue as:
3, 4, null, 5, 6, null, 5, 6, null, 7, 8, null

So this last one I'm not too sure if you like it. It makes sense to me from technical stance. After all, there's an empty cell, so why wouldn't it be separate sequences? But I don't know if you and your userbase appreciate the technical stance on this.
I might be able to fix this for null-cells. But when instead the pattern becomes:
1,2,SomeText,3,4,SomeText
it'll become vague. So I actually rather not work around it, unless you think it's a must. 

My expectation on the grand scale is that these tricky patterns are rare anyway. :-)

Love to hear what you think!
