### PR TITLE
Fix/script rotation angle

### DIFF
--- a/Editor/Properties/AssemblyInfo.cs
+++ b/Editor/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.1.0")]
-[assembly: AssemblyFileVersion("2.0.1.0")]
+[assembly: AssemblyVersion("2.1.0.0")]
+[assembly: AssemblyFileVersion("2.1.0.0")]

--- a/Editor/PropertyPages/AlignmentPage.cs
+++ b/Editor/PropertyPages/AlignmentPage.cs
@@ -94,7 +94,7 @@ namespace unvell.ReoGrid.Editor.PropertyPages
 		private ReoGridHorAlign backupHorAlign;
 		private ReoGridVerAlign backupVerAlign;
 		private ushort backupIndent = 0;
-		private int backupRotateAngle = 0;
+		private float backupRotateAngle = 0;
 
 		public void LoadPage()
 		{
@@ -148,14 +148,14 @@ namespace unvell.ReoGrid.Editor.PropertyPages
 
 			// cell text rotate
 
-			var angle = style.RotateAngle;
+			var angle = style.RotationAngle;
 
 			if (angle < -90) angle = -90;
 			if (angle > 90) angle = 90;
 
 			backupRotateAngle = angle;
-			textRotateControl.Angle = angle;
-			numRotationAngle.Value = angle;
+			textRotateControl.Angle = (int)angle;
+			numRotationAngle.Value = (int)angle;
 		}
 
 		public WorksheetReusableAction CreateUpdateAction()
@@ -218,8 +218,8 @@ namespace unvell.ReoGrid.Editor.PropertyPages
 
 			if (backupRotateAngle != textRotateControl.Angle)
 			{
-				style.RotateAngle = textRotateControl.Angle;
-				style.Flag |= PlainStyleFlag.RotateAngle;
+				style.RotationAngle = textRotateControl.Angle;
+				style.Flag |= PlainStyleFlag.RotationAngle;
 			}
 
 			return style.Flag == PlainStyleFlag.None ? null : new SetRangeStyleAction(grid.CurrentWorksheet.SelectionRange, style);

--- a/ReoGrid/Core/Cell.cs
+++ b/ReoGrid/Core/Cell.cs
@@ -999,7 +999,7 @@ namespace unvell.ReoGrid
 						this.InnerDisplay = null;
 #if DEBUG
 						Logger.Log("cell", "Cell not attached to any worksheet: {0}", this.Position.ToAddress());
-#endif
+#endif // DEBUG
 					}
 					else
 					{
@@ -1014,9 +1014,9 @@ namespace unvell.ReoGrid
 							this.worksheet.SetCellFormula(this, value);
 							this.worksheet.RecalcCell(this);
 						}
-#else
+#else // FORMULA
 						this.worksheet.SetSingleCellData(this, value);
-#endif
+#endif // FORMULA
 					}
 				}
 			}
@@ -1037,7 +1037,7 @@ namespace unvell.ReoGrid
 
 #if DEBUG
 		private static int _count;
-#endif
+#endif // DEBUG
 
 		internal void CreateOwnStyle()
 		{
@@ -1050,7 +1050,7 @@ namespace unvell.ReoGrid
 			{
 				unvell.Common.Logger.Log("style", "new style created, count: " + _count);
 			}
-#endif
+#endif // DEBUG
 		}
 
 		[NonSerialized]

--- a/ReoGrid/Core/Style.cs
+++ b/ReoGrid/Core/Style.cs
@@ -1586,6 +1586,11 @@ namespace unvell.ReoGrid
 		public int RotateAngle { get; set; }
 
 		/// <summary>
+		/// Get or set rotate angle.
+		/// </summary>
+		public float RotationAngle { get; set; }
+
+		/// <summary>
 		/// Create an empty style set.
 		/// </summary>
 		public WorksheetRangeStyle() { }
@@ -2876,20 +2881,20 @@ namespace unvell.ReoGrid
 		/// <summary>
 		/// Get or set text rotation angle. (-90° ~ 90°)
 		/// </summary>
-		public int RotateAngle
+		public float RotationAngle
 		{
 			get
 			{
 				CheckReferenceValidity();
-				return this.Cell.InnerStyle.RotateAngle;
+				return this.Cell.InnerStyle.RotationAngle;
 			}
 			set
 			{
 				CheckReferenceValidity();
 				this.Worksheet.SetCellStyleOwn(this.Cell, new WorksheetRangeStyle
 				{
-					Flag = PlainStyleFlag.RotateAngle,
-					RotateAngle = value,
+					Flag = PlainStyleFlag.RotationAngle,
+					RotationAngle = value,
 				});
 			}
 		}

--- a/ReoGrid/Core/Style.cs
+++ b/ReoGrid/Core/Style.cs
@@ -1580,6 +1580,7 @@ namespace unvell.ReoGrid
 		/// </summary>
 		public PaddingValue Padding { get; set; }
 
+		[Obsolete("use RotationAngle instead")]
 		/// <summary>
 		/// Get or set rotate angle.
 		/// </summary>
@@ -2876,6 +2877,13 @@ namespace unvell.ReoGrid
 					Padding = value,
 				});
 			}
+		}
+
+		[Obsolete("use RotationAngle instead")]
+		public int RotateAngle
+		{
+			get { return (int)this.RotationAngle; }
+			set { this.RotationAngle = value; }
 		}
 
 		/// <summary>

--- a/ReoGrid/Core/Style.cs
+++ b/ReoGrid/Core/Style.cs
@@ -410,7 +410,7 @@ namespace unvell.ReoGrid
 					| PlainStyleFlag.VerticalAlign
 					| PlainStyleFlag.TextWrap
 					| PlainStyleFlag.Indent
-					| PlainStyleFlag.RotateAngle))
+					| PlainStyleFlag.RotationAngle))
 				{
 					UpdateCellTextBounds(cell);
 				}
@@ -1260,10 +1260,12 @@ namespace unvell.ReoGrid
 		/// </summary>
 		Padding = 0x800000,
 
+		[Obsolete("use RotationAngle instead")]
+		RotateAngle = RotationAngle,
 		/// <summary>
-		/// Rotation angle for cell text (0.8.8 Reserved)
+		/// Rotation angle for cell text
 		/// </summary>
-		RotateAngle = 0x1000000,
+		RotationAngle = 0x1000000,
 
 		/// <summary>
 		/// [Union flag] All flags of font style
@@ -1284,7 +1286,7 @@ namespace unvell.ReoGrid
 		/// <summary>
 		/// [Union flag] All layout styles (Text-wrap, padding and angle)
 		/// </summary>
-		LayoutAll = TextWrap | Padding | RotateAngle,
+		LayoutAll = TextWrap | Padding | RotationAngle,
 
 		/// <summary>
 		/// [Union flag] Both horizontal and vertical alignments
@@ -1669,8 +1671,8 @@ namespace unvell.ReoGrid
 				&& this.Indent != s2.Indent) return false;
 			if ((this.Flag & PlainStyleFlag.Padding) == PlainStyleFlag.Padding
 				&& this.Padding != s2.Padding) return false;
-			if ((this.Flag & PlainStyleFlag.RotateAngle) == PlainStyleFlag.RotateAngle
-				&& this.RotateAngle != s2.RotateAngle) return false;
+			if ((this.Flag & PlainStyleFlag.RotationAngle) == PlainStyleFlag.RotationAngle
+				&& this.RotationAngle != s2.RotationAngle) return false;
 
 			return true;
 		}
@@ -1773,7 +1775,7 @@ namespace unvell.ReoGrid
 				case PlainStyleFlag.FontStyleStrikethrough: style.Strikethrough = (bool)(object)value; break;
 				case PlainStyleFlag.HorizontalAlign: style.HAlign = (ReoGridHorAlign)(object)value; break;
 				case PlainStyleFlag.VerticalAlign: style.VAlign = (ReoGridVerAlign)(object)value; break;
-				case PlainStyleFlag.RotateAngle: style.RotateAngle = (int)(object)value; break;
+				case PlainStyleFlag.RotationAngle: style.RotationAngle = (int)(object)value; break;
 			}
 
 			this.Worksheet.SetRangeStyles(row, col, rows, cols, style);

--- a/ReoGrid/IO/ExcelReader.cs
+++ b/ReoGrid/IO/ExcelReader.cs
@@ -1228,11 +1228,11 @@ namespace unvell.ReoGrid.IO.OpenXML
 
 					if (int.TryParse(style.alignment.textRotation, out angle))
 					{
-						styleset.Flag |= PlainStyleFlag.RotateAngle;
+						styleset.Flag |= PlainStyleFlag.RotationAngle;
 
 						if (angle > 90) angle = 90 - angle;
 
-						styleset.RotateAngle = angle;
+						styleset.RotationAngle = angle;
 					}
 				}
 			}

--- a/ReoGrid/IO/ExcelWriter.cs
+++ b/ReoGrid/IO/ExcelWriter.cs
@@ -620,8 +620,8 @@ namespace unvell.ReoGrid.IO.OpenXML
 					textWrap = true;
 				}
 
-				if ((rgStyle.Flag & PlainStyleFlag.RotateAngle) == PlainStyleFlag.RotateAngle
-					&& rgStyle.RotateAngle != 0)
+				if ((rgStyle.Flag & PlainStyleFlag.RotationAngle) == PlainStyleFlag.RotationAngle
+					&& rgStyle.RotationAngle != 0)
 				{
 					textRotate = true;
 				}
@@ -644,7 +644,7 @@ namespace unvell.ReoGrid.IO.OpenXML
 				&& ((textWrap && s.alignment != null && s.alignment.wrapText == "1")
 				|| (!textWrap && (s.alignment == null || s.alignment.wrapText == null)))
 
-				&& ((textRotate && s.alignment != null && s.alignment._rotateAngle == (int)rgStyle.RotateAngle)
+				&& ((textRotate && s.alignment != null && s.alignment._rotateAngle == (int)rgStyle.RotationAngle)
 				|| (!textRotate && (s.alignment == null || s.alignment.textRotation == null)))
 
 				);
@@ -691,8 +691,8 @@ namespace unvell.ReoGrid.IO.OpenXML
 
 				if (textRotate)
 				{
-					align._rotateAngle = rgStyle.RotateAngle;
-					align.textRotation = (rgStyle.RotateAngle < 0 ? Math.Abs(rgStyle.RotateAngle - 90) : rgStyle.RotateAngle).ToString();
+					align._rotateAngle = (int)rgStyle.RotationAngle;
+					align.textRotation = (rgStyle.RotationAngle < 0 ? Math.Abs(rgStyle.RotationAngle - 90) : rgStyle.RotationAngle).ToString();
 				}
 
 				style.applyAlignment = "true";

--- a/ReoGrid/Script/RSObjects.cs
+++ b/ReoGrid/Script/RSObjects.cs
@@ -614,7 +614,7 @@ namespace unvell.ReoGrid.Script
 							Flag = PlainStyleFlag.BackColor,
 							BackColor = color,
 						});
-						
+
 						this.sheet.RequestInvalidate();
 					}
 				});
@@ -632,16 +632,16 @@ namespace unvell.ReoGrid.Script
 							Flag = PlainStyleFlag.TextColor,
 							TextColor = color,
 						});
-				
+
 						this.sheet.RequestInvalidate();
 					}
 				});
 
-			this["fontName"] = new ExternalProperty(() => cell.Style.FontName, 
+			this["fontName"] = new ExternalProperty(() => cell.Style.FontName,
 				(v) => cell.Style.FontName = ScriptRunningMachine.ConvertToString(v));
 
 			this["fontSize"] = new ExternalProperty(
-				() => cell.Style.FontSize, 
+				() => cell.Style.FontSize,
 				(v) => cell.Style.FontSize = TextFormatHelper.GetFloatPixelValue(ScriptRunningMachine.ConvertToString(v),
 					System.Drawing.SystemFonts.DefaultFont.Size));
 
@@ -666,6 +666,19 @@ namespace unvell.ReoGrid.Script
 					{
 						Flag = PlainStyleFlag.VerticalAlign,
 						VAlign = XmlFileFormatHelper.DecodeVerticalAlign(ScriptRunningMachine.ConvertToString(v)),
+					});
+
+					this.sheet.RequestInvalidate();
+				});
+
+			this["rotationAngle"] = new ExternalProperty(
+				() => cell.Style.VAlign,
+				(v) =>
+				{
+					this.sheet.SetCellStyleOwn(cell.InternalPos, new WorksheetRangeStyle
+					{
+						Flag = PlainStyleFlag.RotationAngle,
+						RotationAngle = ScriptRunningMachine.GetFloatValue(v),
 					});
 
 					this.sheet.RequestInvalidate();

--- a/ReoGrid/Utility/StyleUtility.cs
+++ b/ReoGrid/Utility/StyleUtility.cs
@@ -122,10 +122,10 @@ namespace unvell.ReoGrid.Utility
 				distinctedFlag &= ~PlainStyleFlag.Padding;
 			}
 
-			if (StyleUtility.HasStyle(style, PlainStyleFlag.RotateAngle)
-				&& style.RotateAngle == referStyle.RotateAngle)
+			if (StyleUtility.HasStyle(style, PlainStyleFlag.RotationAngle)
+				&& style.RotationAngle == referStyle.RotationAngle)
 			{
-				distinctedFlag &= ~PlainStyleFlag.RotateAngle;
+				distinctedFlag &= ~PlainStyleFlag.RotationAngle;
 			}
 
 			return distinctedFlag;
@@ -236,8 +236,8 @@ namespace unvell.ReoGrid.Utility
 			if ((flag & PlainStyleFlag.Padding) == PlainStyleFlag.Padding)
 				targetStyle.Padding = sourceStyle.Padding;
 
-			if ((flag & PlainStyleFlag.RotateAngle) == PlainStyleFlag.RotateAngle)
-				targetStyle.RotateAngle = sourceStyle.RotateAngle;
+			if ((flag & PlainStyleFlag.RotationAngle) == PlainStyleFlag.RotationAngle)
+				targetStyle.RotationAngle = sourceStyle.RotationAngle;
 
 			targetStyle.Flag |= flag;
 		}
@@ -327,10 +327,10 @@ namespace unvell.ReoGrid.Utility
 			else if ((flag2 & PlainStyleFlag.Padding) == PlainStyleFlag.Padding)
 				style.Padding = style2.Padding;
 
-			if ((flag1 & PlainStyleFlag.RotateAngle) == PlainStyleFlag.RotateAngle)
-				style.RotateAngle = style1.RotateAngle;
-			else if ((flag2 & PlainStyleFlag.RotateAngle) == PlainStyleFlag.RotateAngle)
-				style.RotateAngle = style2.RotateAngle;
+			if ((flag1 & PlainStyleFlag.RotationAngle) == PlainStyleFlag.RotationAngle)
+				style.RotationAngle = style1.RotationAngle;
+			else if ((flag2 & PlainStyleFlag.RotationAngle) == PlainStyleFlag.RotationAngle)
+				style.RotationAngle = style2.RotationAngle;
 
 			return style;
 		}
@@ -432,8 +432,8 @@ namespace unvell.ReoGrid.Utility
 				xmlStyle.indent = style.Indent.ToString();
 			if (StyleUtility.HasStyle(style, PlainStyleFlag.Padding))
 				xmlStyle.padding = TextFormatHelper.EncodePadding(style.Padding);
-			if (StyleUtility.HasStyle(style, PlainStyleFlag.RotateAngle))
-				xmlStyle.rotateAngle = style.RotateAngle.ToString();
+			if (StyleUtility.HasStyle(style, PlainStyleFlag.RotationAngle))
+				xmlStyle.rotateAngle = style.RotationAngle.ToString();
 
 			return xmlStyle;
 		}
@@ -562,8 +562,8 @@ namespace unvell.ReoGrid.Utility
 			if (!string.IsNullOrEmpty(xmlStyle.rotateAngle) 
 				&& int.TryParse(xmlStyle.rotateAngle, out angle))
 			{
-				style.Flag |= PlainStyleFlag.RotateAngle;
-				style.RotateAngle = angle;
+				style.Flag |= PlainStyleFlag.RotationAngle;
+				style.RotationAngle = angle;
 			}
 
 			return style;
@@ -655,8 +655,8 @@ namespace unvell.ReoGrid.Utility
 				&& styleA.Padding != styleB.Padding)
 				return false;
 
-			if (styleA.HasStyle(PlainStyleFlag.RotateAngle)
-				&& styleA.RotateAngle != styleB.RotateAngle)
+			if (styleA.HasStyle(PlainStyleFlag.RotationAngle)
+				&& styleA.RotationAngle != styleB.RotationAngle)
 				return false;
 
 			return true;
@@ -687,7 +687,7 @@ namespace unvell.ReoGrid.Utility
 				case PlainStyleFlag.TextWrap: return style.TextWrapMode;
 				case PlainStyleFlag.Indent: return style.Indent;
 				case PlainStyleFlag.Padding: return style.Padding;
-				case PlainStyleFlag.RotateAngle: return style.RotateAngle;
+				case PlainStyleFlag.RotationAngle: return style.RotationAngle;
 
 				default: return null;
 			}

--- a/ReoGrid/WinForm/Graphics.cs
+++ b/ReoGrid/WinForm/Graphics.cs
@@ -713,7 +713,7 @@ namespace unvell.ReoGrid.WinForm
 				var g = base.PlatformGraphics;
 
 				#region Rotate text
-				if (cell.InnerStyle.RotateAngle != 0)
+				if (cell.InnerStyle.RotationAngle != 0)
 				{
 #if DEBUG1
 					g.DrawRectangle(Pens.Red, (System.Drawing.Rectangle)textBounds);
@@ -722,7 +722,7 @@ namespace unvell.ReoGrid.WinForm
 					this.PushTransform();
 
 					this.TranslateTransform(textBounds.OriginX, textBounds.OriginY);
-					this.RotateTransform(-cell.InnerStyle.RotateAngle);
+					this.RotateTransform(-cell.InnerStyle.RotationAngle);
 
 					sf.LineAlignment = StringAlignment.Center;
 					sf.Alignment = StringAlignment.Center;
@@ -815,9 +815,9 @@ namespace unvell.ReoGrid.WinForm
 
 			//if (sf == null) sf = new System.Drawing.StringFormat(System.Drawing.StringFormat.GenericTypographic);
 
-			if (cell.Style.RotateAngle != 0)
+			if (cell.Style.RotationAngle != 0)
 			{
-				double d = (style.RotateAngle * Math.PI / 180.0d);
+				double d = (style.RotationAngle * Math.PI / 180.0d);
 				s = Math.Sin(d);
 				c = Math.Cos(d);
 			}
@@ -836,7 +836,7 @@ namespace unvell.ReoGrid.WinForm
 					// get cell available width
 					float cellWidth = 0;
 
-					if (cell.Style.RotateAngle != 0)
+					if (cell.Style.RotationAngle != 0)
 					{
 						cellWidth = (float)(Math.Abs(cell.Bounds.Width * c) + Math.Abs(cell.Bounds.Height * s));
 					}
@@ -888,7 +888,7 @@ namespace unvell.ReoGrid.WinForm
 				SizeF size = g.MeasureString(cell.DisplayText, scaledFont, fieldWidth, sf);
 				size.Height++;
 
-				if (style.RotateAngle != 0)
+				if (style.RotationAngle != 0)
 				{
 					float w = (float)(Math.Abs(size.Width * c) + Math.Abs(size.Height * s));
 					float h = (float)(Math.Abs(size.Width * s) + Math.Abs(size.Height * c));


### PR DESCRIPTION
- rename `RotateAngle` property of cell style object to `RotationAngle`
- change property type of `RotateAngle` from `int` to `float`
- fix `rotateAngle` script style object not working problem (#72)
- update editor version to 2.1.0.0