### PR TITLE
Fixed wpf scroll behaviour

### DIFF
--- a/ReoGrid/Views/NormalViewportController.cs
+++ b/ReoGrid/Views/NormalViewportController.cs
@@ -884,16 +884,16 @@ namespace unvell.ReoGrid.Views
 
 			if ((dir & ScrollDirection.Horizontal) == ScrollDirection.Horizontal)
 			{
-				if (scrollHorValue + x > scrollHorMax - scrollHorLarge)
-					x = scrollHorMax - scrollHorLarge - scrollHorValue;
+				if (scrollHorValue + x > scrollHorMax)
+					x = scrollHorMax - scrollHorValue;
 				if (scrollHorValue + x < scrollHorMin)
 					x = scrollHorMin - scrollHorValue;
 			}
 
 			if ((dir & ScrollDirection.Vertical) == ScrollDirection.Vertical)
 			{
-				if (scrollVerValue + y > scrollVerMax - scrollVerLarge)
-					y = scrollVerMax - scrollVerLarge - scrollVerValue;
+				if (scrollVerValue + y > scrollVerMax)
+					y = scrollVerMax - scrollVerValue;
 				if (scrollVerValue + y < scrollVerMin)
 					y = scrollVerMin - scrollVerValue;
 			}
@@ -1079,25 +1079,25 @@ namespace unvell.ReoGrid.Views
 
 			if (worksheet.cols.Count > 0)
 			{
-				width = worksheet.cols[worksheet.cols.Count - 1].Right + mainViewport.Width - mainViewport.Width / scale + 1;
+				width = worksheet.cols[worksheet.cols.Count - 1].Right + -mainViewport.Width;
 			}
 
 			if (worksheet.rows.Count > 0)
 			{
-				height = worksheet.rows[worksheet.rows.Count - 1].Bottom + mainViewport.Height - mainViewport.Height / scale + 1;
+				height = worksheet.rows[worksheet.rows.Count - 1].Bottom + -mainViewport.Height;
 			}
 
-			if (this.worksheet.controlAdapter != null
-				&& this.worksheet.controlAdapter.ControlInstance != null
-				&& this.worksheet.controlAdapter.ControlInstance.ShowScrollEndSpacing
-				&& this.worksheet.FreezeArea == FreezeArea.None)
-			{
-				width += 100 / scale;
-				height += 100 / scale;
-			}
+			//if (this.worksheet.controlAdapter != null
+			//	&& this.worksheet.controlAdapter.ControlInstance != null
+			//	&& this.worksheet.controlAdapter.ControlInstance.ShowScrollEndSpacing
+			//	&& this.worksheet.FreezeArea == FreezeArea.None)
+			//{
+			//	width += 100 / scale;
+			//	height += 100 / scale;
+			//}
 
-			int maxHorizontal = (int)(Math.Round(width + this.mainViewport.Left));
-			int maxVertical = Math.Max(0, (int)(Math.Round(height + this.mainViewport.Top)));
+			int maxHorizontal = (int)(Math.Round(width));
+			int maxVertical = Math.Max(0, (int)(Math.Round(height)));
 
 #if WINFORM || ANDROID
 			int offHor = maxHorizontal - this.scrollHorMax;


### PR DESCRIPTION
Fixed basical arithmetical operations in scrollbar sizing and scrolling behaviour.
I wrote an issue describing the behaviour at issue: #135 

It may be that the original behaviour had some kind of reason behind it that I failed to understand. If this is the case I am happy to resubmit this pull request with the changes mapped to a settings option so the user can switch to this behaviour if they want it

It may be that my changes impact other platforms in unintended ways. I am unable to easily test other platforms but I am happy to move all my changes to "#if WPF" compiler directives

In any case if there is any reason this can not be merged please let me know so I can remedy the situtation