### PR TITLE
Preserve indents and leading/trailing spaces in OpenXML import/export

### DIFF
--- a/ReoGrid/IO/ExcelReader.cs
+++ b/ReoGrid/IO/ExcelReader.cs
@@ -1235,6 +1235,17 @@ namespace unvell.ReoGrid.IO.OpenXML
 						styleset.RotationAngle = angle;
 					}
 				}
+
+				// indent
+				if (!string.IsNullOrEmpty(style.alignment.indent))
+				{
+					ushort indent;
+
+					if (ushort.TryParse(style.alignment.indent, out indent))
+					{
+						styleset.Indent = indent;
+					}
+				}
 			}
 #endregion // Alignment
 

--- a/ReoGrid/IO/ExcelSchame.cs
+++ b/ReoGrid/IO/ExcelSchame.cs
@@ -29,6 +29,7 @@ namespace unvell.ReoGrid.IO.OpenXML.Schema
 	#region Namespaces Definitions
 	internal class OpenXMLNamespaces
 	{
+		internal const string NET_XML______ = "http://www.w3.org/XML/1998/namespace";
 		internal const string NET_XSI______ = "http://www.w3.org/2001/XMLSchema-instance";
 		internal const string NET_XSD______ = "http://www.w3.org/2001/XMLSchema";
 
@@ -1067,8 +1068,19 @@ namespace unvell.ReoGrid.IO.OpenXML.Schema
 		[XmlText]
 		public string val;
 
+		[XmlAttribute("space", Namespace = OpenXMLNamespaces.NET_XML______)]
+		public string space;
+
 		public ElementText() { }
-		internal ElementText(string val) { this.val = val; }
+
+		internal ElementText(string val)
+		{
+			this.val = val;
+			if (val.Length > 0 && (Char.IsWhiteSpace(val[0]) || Char.IsWhiteSpace(val[val.Length - 1])))
+			{
+				this.space = "preserve";
+			}
+		}
 
 		public static implicit operator string(ElementText t)
 		{

--- a/ReoGrid/IO/ExcelWriter.cs
+++ b/ReoGrid/IO/ExcelWriter.cs
@@ -676,6 +676,10 @@ namespace unvell.ReoGrid.IO.OpenXML
 				{
 					align.horizontal = ConvertToExcelHorAlign(rgStyle.HAlign);
 					align._horAlign = rgStyle.HAlign;
+					if (rgStyle.HAlign == ReoGridHorAlign.Left)
+					{
+						align.indent = Convert.ToString(rgStyle.Indent);
+					}
 				}
 
 				if (verAlign)


### PR DESCRIPTION
Fixes the #159 issue.
Adds the `indent` style on import and export, and includes the `xml:space="preserve"` attribute when exporting cell values with leading or trailing whitespaces.