### PR TITLE
saving image in rgf support

### DIFF
--- a/ReoGrid/Core/Cell.cs
+++ b/ReoGrid/Core/Cell.cs
@@ -235,6 +235,20 @@ namespace unvell.ReoGrid
 				}
 			}
 
+			// experimental: directly set an image as cell data
+			//
+			//else if (data is System.Drawing.Image)
+			//{
+			//	if (cell.body == null)
+			//	{
+			//		cell.Body = new ImageCell((System.Drawing.Image)data);
+			//	}
+			//	else if (cell.body is ImageCell)
+			//	{
+			//		((ImageCell)cell.body).Image = (System.Drawing.Image)data;
+			//	}
+			//}
+
 #if FORMULA
 			if (formulaRanges.Count > 0)
 			{


### PR DESCRIPTION
## Changes

- Save image in RGF format

## Description
Now saving image in RGF file has been supported. Note that this only works when using ReoGrid built-in cell body: `CellTypes.ImageCell`

e.g.
```csharp
sheet["A1"] = new ImageCell(Resources.outline_solid_32);
```

Save as RGF
```csharp
sheet.SaveRGF("myworksheet.rgf");
```

Load from RGF
```csharp
sheet.LoadRGF("myworksheet.rgf");
```

## Remark
RGF file is XML-base file format for save single ReoGrid worksheet data. The image will be stored as base64 string.
```xml
...
<cell row="0" col="0" body-type="ImageCell">image/png,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAK7gAACu4BrzForAAAACV0RVh0U29mdHdhcmUATWFjcm9tZWRpYSBGaXJld29ya3MgTVggMjAwNId2rM8AAAEBSURBVEhLzZOBDcMgDASzEztlJ3bKTmk/0ldf16DYkCaVToBNOdmQpZSy38EzxOu6HujcW3sxrr1zdCQfMRLv33IlKk+Jt23ba60HmNt8C1cM7MYWFGOMiNWVrphym+sx3Oos08SRNgNXDOzGFmxz9HGpa/iOI+LhVlNMbL4FXWlxlm7FXiW9mF33Yq4YIMl702/UPiTm9VDG9H82pq6firmRB3oxPdDGMDLGNUasn9Vqiq/EFQO7sYVWwmrOoK5UxZDZOz7DlIrtQzqDulIVk4gUuBVnxFGmtFqx+RbqSlUMGR+XzfUYbjUrnfKqI+IsrphyomvOZ+whX+J/cpO47C+zKABM1P+eGgAAAABJRU5ErkJggg==</cell>
```