### PR TITLE
fix a bug during loading Excel file

### DIFF
--- a/ReoGrid/IO/ExcelReader.cs
+++ b/ReoGrid/IO/ExcelReader.cs
@@ -235,22 +235,30 @@ namespace unvell.ReoGrid.IO.OpenXML
 			}
 			#endregion // SheetFormatProperty
 
-			#region Dimension
+			#region Resize
 			// resize to dimension 
+
+			int sheetRowCount = sheet.rows.Count;
+			int sheetColCount = sheet.cols.Count;
+
 			if (sheet.dimension != null && !string.IsNullOrEmpty(sheet.dimension.address))
 			{
 				RangePosition contentRange = new RangePosition(sheet.dimension.address);
 
-				if (rgSheet.RowCount <= contentRange.EndRow)
-				{
-					rgSheet.Rows = contentRange.EndRow + 1;
-				}
-				if (rgSheet.ColumnCount <= contentRange.EndCol)
-				{
-					rgSheet.Columns = contentRange.EndCol + 1;
-				}
+				sheetRowCount = Math.Max(sheetRowCount, contentRange.EndRow + 1);
+				sheetColCount = Math.Max(sheetColCount, contentRange.EndCol + 1);
 			}
-			#endregion // Dimension
+
+			if (rgSheet.RowCount < sheetRowCount)
+			{
+				rgSheet.Rows = sheetRowCount;
+			}
+
+			if (rgSheet.ColumnCount < sheetColCount)
+			{
+				rgSheet.Columns = sheetColCount;
+			}
+			#endregion // Resize
 
 			#region Columns
 			// columns


### PR DESCRIPTION
# Fix bug

Avoid exception happen from loading Excel file that is generated by Google Spreadsheet.

# Why exception happens

ReoGrid reset worksheet before loading all cells, the new size is read from `dimension` element of worksheet XML file, some programs except Excel may don't provide this XML element. Since the size can be also get from collection of rows and columns. So ReoGrid should decide the new size according to either collection or dimension element.
