### PR TITLE
Fix/action performed event triggered twice

### DIFF
--- a/ReoGrid/Control/ControlShare.cs
+++ b/ReoGrid/Control/ControlShare.cs
@@ -909,9 +909,9 @@ namespace unvell.ReoGrid
 				}
 			}
 
-			if (this.actionManager.CanRedo())
+			if (this.CanRedo())
 			{
-				this.actionManager.Redo();
+				this.Redo();
 			}
 			else
 			{

--- a/ReoGrid/Control/ControlShare.cs
+++ b/ReoGrid/Control/ControlShare.cs
@@ -788,7 +788,9 @@ namespace unvell.ReoGrid
 				this.CurrentWorksheet = sheet;
 			}
 
-			if (ActionPerformed != null) ActionPerformed(this, new WorkbookActionEventArgs(action));
+			// fix #282, https://github.com/unvell/ReoGrid/issues/282
+			// comment out to avoid invoke ActionPerformed event, which is already invoked by actionManager above.
+			//if (ActionPerformed != null) ActionPerformed(this, new WorkbookActionEventArgs(action));
 		}
 
 		/// <summary>
@@ -920,7 +922,8 @@ namespace unvell.ReoGrid
 
 					this.actionManager.DoAction(newAction);
 
-					this.ActionPerformed?.Invoke(this, new WorkbookActionEventArgs(newAction));
+					// fix #282, https://github.com/unvell/ReoGrid/issues/282
+					//this.ActionPerformed?.Invoke(this, new WorkbookActionEventArgs(newAction));
 
 					this.currentWorksheet.RequestInvalidate();
 				}


### PR DESCRIPTION
Fix #282

- Fix bug that `actionPerformed` event triggered twice #282
- improve redo-action operation invoked from repeat-last-action