### PR TITLE
fixes bug to prevent scroll reset to zero

### DIFF
--- a/ReoGrid/Worksheet.cs
+++ b/ReoGrid/Worksheet.cs
@@ -429,6 +429,9 @@ namespace unvell.ReoGrid
 			////}
 		}
 
+		private CellPosition lastFrozenPosition;
+		private FreezeArea lastFrozenArea = FreezeArea.None;
+
 		/// <summary>
 		/// Freezes worksheet at specified cell position and specifies the freeze areas.
 		/// </summary>
@@ -437,6 +440,18 @@ namespace unvell.ReoGrid
 		/// <param name="area">Specifies the frozen panes.</param>
 		public void FreezeToCell(int row, int col, FreezeArea area)
 		{
+			/////////////////////////////////////////////////////////////////
+			// fix issue #151, #172, #313
+			if (lastFrozenPosition == new CellPosition(row, col) && lastFrozenArea == area)
+			{
+				// skip to perform freeze if forzen position and area are not changed
+				return;
+			}
+
+			lastFrozenPosition = new CellPosition(row, col);
+			lastFrozenArea = area;
+			/////////////////////////////////////////////////////////////////
+
 			if (this.viewportController != null)
 			{
 				// update viewport bounds - sometimes the viewport may cannot get the correct size for freezing,


### PR DESCRIPTION
When worksheet has frozen region, change row header or column width, hide or show rows and columns, will cause scroll reset to zero.

Fixes bug #151, #172, #313 