### PR TITLE
Update HyperLinkCell.cs

### DIFF
--- a/ReoGrid/CellTypes/HyperLinkCell.cs
+++ b/ReoGrid/CellTypes/HyperLinkCell.cs
@@ -96,18 +96,9 @@ namespace unvell.ReoGrid.CellTypes
 		}
 
 		/// <summary>
-		/// Determine whether or not the hyperlink is in pressed status.
+		/// Determine whether or not the mouse is over the hyperlink.
 		/// </summary>
-		public bool IsPressed { get; set; }
-
-		/// <summary>
-		/// Handle event when the cell of this body entered edit mode.
-		/// </summary>
-		/// <returns>True to allow edit; False to disallow edit.</returns>
-		public override bool OnStartEdit()
-		{
-			return !this.IsPressed;
-		}
+		public bool IsOverLink { get; set; }
 
 		/// <summary>
 		/// Initialize cell body when set up into a cell.
@@ -137,11 +128,12 @@ namespace unvell.ReoGrid.CellTypes
 		/// <returns>True if event has been handled.</returns>
 		public override bool OnMouseDown(CellMouseEventArgs e)
 		{
-			this.IsPressed = true;
+			if (this.IsOverLink)
+			{
+				e.Cell.Style.TextColor = ActivateColor;
+			}
 
-			e.Cell.Style.TextColor = ActivateColor;
-
-			return true;
+			return base.OnMouseDown(e);
 		}
 
 		/// <summary>
@@ -151,32 +143,44 @@ namespace unvell.ReoGrid.CellTypes
 		/// <returns>True if event has been handled.</returns>
 		public override bool OnMouseUp(CellMouseEventArgs e)
 		{
-			if (this.IsPressed)
+			if (this.IsOverLink)
 			{
-				if (this.Bounds.Contains(e.RelativePosition))
-				{
-					this.PerformClick();
-				}
+				this.IsOverLink = false;
+				e.Cell.Style.TextColor = VisitedColor;
+				this.PerformClick();
+				return true;
 			}
 
-			this.IsPressed = false;
-
-			e.Cell.Style.TextColor = VisitedColor;
-
-			return true;
+			return base.OnMouseUp(e);
 		}
-
+		
 		/// <summary>
-		/// Change color of hyperlink to hover-status when mouse moved into the cell.
+		/// Determine whether the mouse is over the link and change the cursor accordingly.
 		/// </summary>
 		/// <param name="e">Event argument of cell body mouse-enter.</param>
 		/// <returns>True if event has been handled.</returns>
-		public override bool OnMouseEnter(CellMouseEventArgs e)
+		public override bool OnMouseMove(CellMouseEventArgs e)
 		{
-			e.Worksheet.controlAdapter.ChangeSelectionCursor(CursorStyle.Hand);
-			return false;
-		}
+			if (e.Cell.TextBounds.Contains(e.RelativePosition))
+			{
+				if (!this.IsOverLink)
+				{
+					this.IsOverLink = true;
+					e.Worksheet.controlAdapter.ChangeSelectionCursor(CursorStyle.Hand);
+				}
+			}
+			else
+			{
+				if (this.IsOverLink)
+				{
+					this.IsOverLink = false;
+					e.Worksheet.controlAdapter.ChangeSelectionCursor(CursorStyle.PlatformDefault);
+				}
+			}
 
+			return base.OnMouseMove(e);
+		}		
+		
 		/// <summary>
 		/// Restore color of hyperlink from hover-status when mouse leaved from cell.
 		/// </summary>
@@ -185,51 +189,12 @@ namespace unvell.ReoGrid.CellTypes
 		public override bool OnMouseLeave(CellMouseEventArgs e)
 		{
 			// change current cursor to hand
-			e.Worksheet.ControlAdapter.ChangeSelectionCursor(CursorStyle.PlatformDefault);
-			return false;
-		}
-
-		/// <summary>
-		/// Handle keyboard down event.
-		/// </summary>
-		/// <param name="keyCode">Virtual keys code that is converted from system platform.</param>
-		/// <returns>True if event has been handled; Otherwise return false.</returns>
-		public override bool OnKeyDown(KeyCode keyCode)
-		{
-			if (keyCode == KeyCode.Space)
+			if (this.IsOverLink)
 			{
-				this.IsPressed = true;
-				this.Cell.Style.TextColor = ActivateColor;
-
-				return true;
+				this.IsOverLink = false;
+				e.Worksheet.controlAdapter.ChangeSelectionCursor(CursorStyle.PlatformDefault);
 			}
-			else
-			{
-				return false;
-			}
-		}
-
-		/// <summary>
-		/// Handle keyboard up event.
-		/// </summary>
-		/// <param name="keyCode">Virtual keys code that is converted from system platform.</param>
-		/// <returns>True if event has been handled; Otherwise return false;</returns>
-		public override bool OnKeyUp(KeyCode keyCode)
-		{
-			if (IsPressed)
-			{
-				this.IsPressed = false;
-
-				this.PerformClick();
-
-				this.Cell.Style.TextColor = VisitedColor;
-
-				return true;
-			}
-			else
-			{
-				return false;
-			}
+			return base.OnMouseLeave(e);
 		}
 
 		/// <summary>
@@ -237,9 +202,9 @@ namespace unvell.ReoGrid.CellTypes
 		/// </summary>
 		public override void OnLostFocus()
 		{
-			if (this.IsPressed)
+			if (this.IsOverLink)
 			{
-				this.IsPressed = false;
+				this.IsOverLink = false;
 			}
 		}
 


### PR DESCRIPTION
I've made all the modifications based on the behavior of the Latest Excel under Windows: the cursor change only when the mouse is over the text.

To achieve that:
1. I've changed the name of the property from IsPressed to IsOverLink.
2. I've removed OnStartEdit because you can still edit the cell even if the mouse is over the link.
3. I've remove the event OnMouseEnter and replaced them with OnMouseMove. OnMouseLeave is still there.
4. OnMouse mouse check if the mouse is over the text and change IsOverLink accordingly and manage the cursor
5. For each events, the default behavior is kept. Example: Even if the mouse is down over the text, you can still move outside the cell and select a range
6. In Excel, with the mouse down over the link, if you move the mouse before mouse up, the navigate process is stopped. Unfortunately, I couldn't reproduce since when the mouse is down, OnMouseMove isn't receiving any event. Not sure why. Same for OnMouseLeave, not sure it's useful.