### PR TITLE
possible problems with 1-column worksheet

### DIFF
--- a/ReoGrid/IO/ExcelWriter.cs
+++ b/ReoGrid/IO/ExcelWriter.cs
@@ -1000,10 +1000,17 @@ namespace unvell.ReoGrid.IO.OpenXML
 			var dpix = PlatformUtility.GetDPI();
 			const float fixedCharWidth = 7f; // todo: get from default font
 			const float columnWidthPad = 0f; // todo: openxml std: 5f
-
-			int maxRows = Math.Max(rgSheet.MaxContentRow, 1);
-			int maxCols = Math.Max(rgSheet.MaxContentCol, 1);
-
+			int maxRows,maxCols;
+			if(rgSheet.MaxContentRow != 1 || rgSheet.MaxContentCol != 1)
+			{
+				maxRows = Math.Max(rgSheet.MaxContentRow, 1);
+				maxCols = Math.Max(rgSheet.MaxContentCol, 1);
+			}
+			else
+			{
+				maxRows = 0;
+				maxCols = 0;
+			}
 			#region Sheet Properties
 
 			var dimensionRange = new RangePosition(0, 0, maxRows + 1, maxCols + 1);


### PR DESCRIPTION
If the worksheet is resized to 1 row or 1 column, throws out of range exception, I guess, here
```csharp
var dimensionRange = new RangePosition(0, 0, maxRows + 1, maxCols + 1);
```

Didn't check the loops 
```csharp
  for (int r = 0; r <= maxRows; r++)
```
and
```csharp
  for (int c = 0; c <= maxCols;)
```
in this merge
may be you could better.
Regards