### PR TITLE
fix background overflow bug 

### DIFF
--- a/ReoGrid/CellTypes/CellBody.cs
+++ b/ReoGrid/CellTypes/CellBody.cs
@@ -144,7 +144,6 @@ namespace unvell.ReoGrid.CellTypes
 		/// <param name="dc">Platform independency graphics context.</param>
 		public virtual void OnPaint(CellDrawingContext dc)
 		{
-			dc.DrawCellBackground();
 			dc.DrawCellText();
 		}
 
@@ -267,7 +266,6 @@ namespace unvell.ReoGrid.CellTypes
 		/// <param name="dc">Platform independency graphics context.</param>
 		public override void OnPaint(CellDrawingContext dc)
 		{
-			dc.DrawCellBackground();
 
 			if (this.ContentBounds.Width > 0 || this.ContentBounds.Height > 0)
 			{


### PR DESCRIPTION
removed cellbody drawbackgroud function to prevent backgroud overflow when scaling cellview.
![image](https://user-images.githubusercontent.com/37168524/93305855-b01d0800-f831-11ea-8ebf-46e7a4d58740.png)
