### PR TITLE
ExcelReader: Assume en-us locale when parsing row.height so fractiona…

### DIFF
--- a/ReoGrid/IO/ExcelReader.cs
+++ b/ReoGrid/IO/ExcelReader.cs
@@ -375,7 +375,8 @@ namespace unvell.ReoGrid.IO.OpenXML
 
 				if (//row.customHeight == "1"
 						//&& 
-					!string.IsNullOrEmpty(row.height) && double.TryParse(row.height, out rowHeight))
+					!string.IsNullOrEmpty(row.height) && double.TryParse(row.height, System.Globalization.NumberStyles.Number,
+					ExcelWriter.EnglishCulture, out rowHeight))
 				{
 					rowHeader = rgSheet.GetRowHeader(rowIndex);
 					ushort height = (ushort)Math.Round(rowHeight * dpi / 72f);


### PR DESCRIPTION
…l part is properly recognized