### PR TITLE
Fixes the problem that parameter list cannot be parsed correctly

### DIFF
--- a/ReoGrid/Formula/FormulaExtension.cs
+++ b/ReoGrid/Formula/FormulaExtension.cs
@@ -30,6 +30,26 @@ namespace unvell.ReoGrid.Formula
 	/// </summary>
 	public class FormulaExtension
 	{
+		/// <summary>
+		/// Specifies the separator of parameter list in formula. Default is "," but will be ';' in some cultures. Change this property before ReoGrid initializing.
+		/// </summary>
+		public static string ParameterSeparator = ",";
+
+		/// <summary>
+		/// Specifies the separator of number decimal format in formula. Default is "." but will be ',' in some cultures. Change this property before ReoGrid initializing.
+		/// </summary>
+		public static string NumberDecimalSeparator = ".";
+
+		static FormulaExtension()
+		{
+			try
+			{
+				ParameterSeparator = System.Threading.Thread.CurrentThread.CurrentCulture.TextInfo.ListSeparator;
+				NumberDecimalSeparator = System.Threading.Thread.CurrentThread.CurrentCulture.NumberFormat.NumberDecimalSeparator;
+			}
+			catch { }
+		}
+
 		internal static Dictionary<string, Func<Cell, object[], object>> customFunctions;
 
 		/// <summary>

--- a/ReoGrid/Formula/Parser.cs
+++ b/ReoGrid/Formula/Parser.cs
@@ -50,17 +50,6 @@ namespace unvell.ReoGrid.Formula
 
 			return node;
 		}
-
-		private static string ParameterSeparator = ",";
-
-		static Parser()
-		{
-			try
-			{
-				ParameterSeparator = System.Threading.Thread.CurrentThread.CurrentCulture.TextInfo.ListSeparator;
-			}
-			catch { }
-		}
 		#endregion // Parser API
 
 		#region Parsers
@@ -305,7 +294,7 @@ namespace unvell.ReoGrid.Formula
 				nodes.Add(node);
 				i++;
 
-				if (!lexer.SkipToken(Parser.ParameterSeparator)) break;
+				if (!lexer.SkipToken(FormulaExtension.ParameterSeparator)) break;
 			}
 
 			while (nodes.Count > 0 && nodes[nodes.Count - 1] == null)
@@ -528,10 +517,11 @@ namespace unvell.ReoGrid.Formula
 			"\\s*((?<string>\"(?:\"\"|[^\"])*\")|(?<union_ranges>[A-Z]+[0-9]+:[A-Z]+[0-9]+(\\s[A-Z]+[0-9]+:[A-Z]+[0-9]+)+)"
 			+ "|(?<range>\\$?[A-Z]+\\$?[0-9]*:\\$?[A-Z]+\\$?[0-9]*)"
 			+ "|(?<cell>\\$?[A-Z]+\\$?[0-9]+)"
-			+ "|(?<token>-)|(?<number>\\-?\\d*\\"
-			+ System.Threading.Thread.CurrentThread.CurrentCulture.NumberFormat.NumberDecimalSeparator + "?\\d+)"
+			+ "|(?<token>-)|(?<number>\\-?\\d*\\" + FormulaExtension.NumberDecimalSeparator + "?\\d+)"
 			+ "|(?<true>(?i)TRUE)|(?<false>(?i)FALSE)|(?<identifier>\\w+)"
-			+ "|(?<token>\\=\\=|\\<\\>|\\<\\=|\\>\\=|\\<\\>|\\=|\\!|[\\=\\.\\,\\+\\-\\*\\/\\%\\<\\>\\(\\)\\&\\^]))",
+			+ "|(?<token>\\=\\=|\\<\\>|\\<\\=|\\>\\=|\\<\\>|\\=|\\!|[\\=\\.\\"
+			+ FormulaExtension.ParameterSeparator // ,
+			+ "\\+\\-\\*\\/\\%\\<\\>\\(\\)\\&\\^]))",
 			RegexOptions.Compiled);
 
 		public string Input { get; set; }


### PR DESCRIPTION
## Fixes

- Fixes the problem that parameter list cannot be parsed correctly in some culture
- Issue #369, #253

## Note: This problem happens only in some cultures

This is problem happens in some specific culture that use ';' as list separator. Formula parser attempts to use ',' to split the parameter list but ';' is defined as token of parameter list.

To reproduce this problem:
```csharp
// Set culture to 'de-CH'
System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("de-CH");
```

## The new API

The two properties has been added to set the separator, the parameter must be changed before ReoGrid is initialized.

e.g.
```csharp
// force to set the parameter separator to ','
Formula.FormulaExtension.ParameterSeparator = ",";
```

