### PR TITLE
Fix bug that worksheet automatically scrolls to the last cell after delete rows or columns

### DIFF
--- a/ReoGrid/Core/Header.cs
+++ b/ReoGrid/Core/Header.cs
@@ -2147,7 +2147,8 @@ namespace unvell.ReoGrid
 
 			UpdateViewportController();
 
-			SelectionRange = FixRange(selectionRange);
+			var selRange = FixRange(selectionRange);
+			ApplyRangeSelection(selRange.StartPos, selRange.EndPos, false);
 
 #if DEBUG
 			sw.Stop();
@@ -2667,8 +2668,9 @@ namespace unvell.ReoGrid
 
 			UpdateViewportController();
 
-			SelectionRange = FixRange(selectionRange);
-
+			var selRange = FixRange(selectionRange);
+			ApplyRangeSelection(selRange.StartPos, selRange.EndPos, false);
+			
 #if DEBUG
 			sw.Stop();
 			long ms = sw.ElapsedMilliseconds;

--- a/ReoGrid/Core/Position.cs
+++ b/ReoGrid/Core/Position.cs
@@ -1555,6 +1555,11 @@ namespace unvell.ReoGrid
 			get { return rows == 1 && cols == 1; }
 		}
 
+		public static RangePosition FromCellPosition(CellPosition startPosition, CellPosition endPosition)
+		{
+			return FromCellPosition(startPosition.Row, startPosition.Col, endPosition.Row, endPosition.Col);
+		}
+
 		/// <summary>
 		/// Create range position instance from specified coordinates. 
 		/// This method finds and uses the minimum and maximum row and column automatically.

--- a/ReoGrid/Core/Worksheet/Selection.cs
+++ b/ReoGrid/Core/Worksheet/Selection.cs
@@ -494,7 +494,7 @@ namespace unvell.ReoGrid
 				}
 				#endregion // Each Operation Status
 
-				this.ApplyRangeSelection(startpos, endpos, true);
+				this.ApplyRangeSelection(startpos, endpos);
 			}
 		}
 		#endregion // Mouse Select
@@ -582,13 +582,18 @@ namespace unvell.ReoGrid
 			return new RangePosition(minr, minc, rows, cols);
 		}
 
-		private void ApplyRangeSelection(CellPosition start, CellPosition end, bool appendSelect)
+		private void MoveRangeSelection(CellPosition start, CellPosition end, bool appendSelect, bool scrollToSelectionEnd = true)
 		{
 			if (!appendSelect)
 			{
 				start = end;
 			}
 
+			this.ApplyRangeSelection(start, end, scrollToSelectionEnd: scrollToSelectionEnd);
+		}
+
+		private void ApplyRangeSelection(CellPosition start, CellPosition end, bool scrollToSelectionEnd = true)
+		{
 			bool processed = false;
 
 			switch (this.operationStatus)
@@ -624,11 +629,12 @@ namespace unvell.ReoGrid
 			if (processed)
 			{
 				if (this.HasSettings(WorksheetSettings.Behavior_ScrollToFocusCell)
-					// commented out before the case of entire row or column 
-					// is checked inside NormalViewportController.ScrollToRange method
-					// issue #179
+					 //commented out before the case of entire row or column
+					 //is checked inside NormalViewportController.ScrollToRange method
+					 //issue #179
 					//&& (this.selectionRange.Rows != this.rows.Count
 					//&& this.selectionRange.Cols != this.cols.Count)
+					&& scrollToSelectionEnd
 					)
 				{
 					// skip to scroll if entire worksheet is selected
@@ -783,7 +789,7 @@ namespace unvell.ReoGrid
 			range = this.FixRange(range);
 
 			// submit to select a range 
-			ApplyRangeSelection(range.StartPos, range.EndPos, true);
+			ApplyRangeSelection(range.StartPos, range.EndPos, false);
 		}
 
 		/// <summary>
@@ -1195,8 +1201,7 @@ namespace unvell.ReoGrid
 
 				if (this.rows[row].InnerHeight > 0)
 				{
-					//selEnd.Row = row;
-					ApplyRangeSelection(selStart, new CellPosition(row, selEnd.Col), appendSelect);
+					MoveRangeSelection(selStart, new CellPosition(row, selEnd.Col), appendSelect);
 					break;
 				}
 			}
@@ -1231,8 +1236,7 @@ namespace unvell.ReoGrid
 
 				if (this.rows[row].InnerHeight > 0)
 				{
-					//selEnd.Row = row;
-					ApplyRangeSelection(this.selStart, new CellPosition(row, selEnd.Col), appendSelect);
+					MoveRangeSelection(this.selStart, new CellPosition(row, selEnd.Col), appendSelect);
 					break;
 				}
 			}
@@ -1268,7 +1272,7 @@ namespace unvell.ReoGrid
 				if (this.cols[col].InnerWidth > 0)
 				{
 					//selEnd.Col = col;
-					ApplyRangeSelection(this.selStart, new CellPosition(selEnd.Row, col), appendSelect);
+					MoveRangeSelection(this.selStart, new CellPosition(selEnd.Row, col), appendSelect);
 					break;
 				}
 			}
@@ -1303,8 +1307,7 @@ namespace unvell.ReoGrid
 
 				if (this.cols[col].InnerWidth > 0)
 				{
-					//selEnd.Col = col;
-					ApplyRangeSelection(selStart, new CellPosition(this.selEnd.Row, col), appendSelect);
+					MoveRangeSelection(selStart, new CellPosition(this.selEnd.Row, col), appendSelect);
 					break;
 				}
 			}
@@ -1337,7 +1340,7 @@ namespace unvell.ReoGrid
 
 			if (endpos != this.selEnd)
 			{
-				ApplyRangeSelection(this.selStart, endpos, appendSelect);
+				MoveRangeSelection(this.selStart, endpos, appendSelect);
 			}
 		}
 
@@ -1368,7 +1371,7 @@ namespace unvell.ReoGrid
 
 			if (endpos != this.selEnd)
 			{
-				ApplyRangeSelection(this.selStart, endpos, appendSelect);
+				MoveRangeSelection(this.selStart, endpos, appendSelect);
 			}
 		}
 
@@ -1407,7 +1410,7 @@ namespace unvell.ReoGrid
 				pos = cell.Position;
 			}
 
-			ApplyRangeSelection(this.selStart, pos, appendSelect);
+			MoveRangeSelection(this.selStart, pos, appendSelect);
 		}
 
 		/// <summary>
@@ -1445,7 +1448,7 @@ namespace unvell.ReoGrid
 				pos = cell.Position;
 			}
 
-			ApplyRangeSelection(this.selStart, pos, appendSelect);
+			MoveRangeSelection(this.selStart, pos, appendSelect);
 		}
 
 		#endregion // Keyboard Move

--- a/ReoGrid/WinForm/WinFormControl.cs
+++ b/ReoGrid/WinForm/WinFormControl.cs
@@ -57,10 +57,10 @@ namespace unvell.ReoGrid
 	/// </summary>
 
 	//[DefaultProperty("Template")]
-//#if WINFORM
-//	[Designer(typeof(ReoGridControlDesigner))]
-//	[ToolboxItem(typeof(ReoGridControlToolboxItem))]
-//#endif // WINFORM
+	//#if WINFORM
+	//	[Designer(typeof(ReoGridControlDesigner))]
+	//	[ToolboxItem(typeof(ReoGridControlToolboxItem))]
+	//#endif // WINFORM
 
 	public partial class ReoGridControl : System.Windows.Forms.Control, IVisualWorkbook,
 		IRangePickableControl, IContextMenuControl, IPersistenceWorkbook, IActionControl, IWorkbook,
@@ -313,7 +313,7 @@ namespace unvell.ReoGrid
 		/// False to release only unmanaged resources.</param>
 		protected override void Dispose(bool disposing)
 		{
-			var gdiRenderer = (GDIRenderer) renderer;
+			var gdiRenderer = (GDIRenderer)renderer;
 
 			if (gdiRenderer != null)
 			{
@@ -438,7 +438,7 @@ namespace unvell.ReoGrid
 					case CursorStyle.Busy: this.control.Cursor = Cursors.WaitCursor; break;
 					case CursorStyle.Hand: this.control.Cursor = Cursors.Hand; break;
 					case CursorStyle.FullColumnSelect:
-						this.control.Cursor = this.control.FullColumnSelectionCursor!=null ?
+						this.control.Cursor = this.control.FullColumnSelectionCursor != null ?
 							this.control.FullColumnSelectionCursor : this.control.builtInFullColSelectCursor;
 						break;
 					case CursorStyle.FullRowSelect:
@@ -1028,58 +1028,58 @@ namespace unvell.ReoGrid
 			{
 				sf = new StringFormat(StringFormat.GenericDefault);
 			}
-            protected override void OnKeyDown(KeyEventArgs e)
-            {
-                var sheet = owner.currentWorksheet;
+			protected override void OnKeyDown(KeyEventArgs e)
+			{
+				var sheet = owner.currentWorksheet;
 
-                if (sheet.currentEditingCell != null && Visible)
-                {
-                    bool isProcessed = false;
+				if (sheet.currentEditingCell != null && Visible)
+				{
+					bool isProcessed = false;
 
-                    // in single line text
-                    if (!TextWrap && Text.IndexOf('\n') == -1)
-                    {
-                        isProcessed = true;
-                        if (e.KeyCode == Keys.Up)
-                        {
-                            ProcessSelectionMoveKey(e, sheet, () => sheet.MoveSelectionUp());
-                        }
-                        else if (e.KeyCode == Keys.Down)
-                        {
-                            ProcessSelectionMoveKey(e, sheet, () => sheet.MoveSelectionDown());
-                        }
-                        else if (e.KeyCode == Keys.Left && SelectionStart == 0)
-                        {
-                            ProcessSelectionMoveKey(e, sheet, () => sheet.MoveSelectionLeft());
-                        }
-                        else if (e.KeyCode == Keys.Right && SelectionStart == Text.Length)
-                        {
-                            ProcessSelectionMoveKey(e, sheet, () => sheet.MoveSelectionRight());
-                        }
-                        else
-                        {
-                            isProcessed = false;
-                        }
-                    }
+					// in single line text
+					if (!TextWrap && Text.IndexOf('\n') == -1)
+					{
+						isProcessed = true;
+						if (e.KeyCode == Keys.Up)
+						{
+							ProcessSelectionMoveKey(e, sheet, () => sheet.MoveSelectionUp());
+						}
+						else if (e.KeyCode == Keys.Down)
+						{
+							ProcessSelectionMoveKey(e, sheet, () => sheet.MoveSelectionDown());
+						}
+						else if (e.KeyCode == Keys.Left && SelectionStart == 0)
+						{
+							ProcessSelectionMoveKey(e, sheet, () => sheet.MoveSelectionLeft());
+						}
+						else if (e.KeyCode == Keys.Right && SelectionStart == Text.Length)
+						{
+							ProcessSelectionMoveKey(e, sheet, () => sheet.MoveSelectionRight());
+						}
+						else
+						{
+							isProcessed = false;
+						}
+					}
 
-                    if (!isProcessed)
-                    {
-                        if (!Toolkit.IsKeyDown(Win32.VKey.VK_CONTROL) && e.KeyCode == Keys.Enter)
-                        {
-                            ProcessSelectionMoveKey(e, sheet, () => sheet.MoveSelectionForward());
-                        }
-                    }
-                }
-            }
+					if (!isProcessed)
+					{
+						if (!Toolkit.IsKeyDown(Win32.VKey.VK_CONTROL) && e.KeyCode == Keys.Enter)
+						{
+							ProcessSelectionMoveKey(e, sheet, () => sheet.MoveSelectionForward());
+						}
+					}
+				}
+			}
 
-            private void ProcessSelectionMoveKey(KeyEventArgs e, Worksheet sheet, Action moveAction)
-            {
-                e.SuppressKeyPress = true;
-                sheet.EndEdit(Text);
-                moveAction();
-            }
+			private void ProcessSelectionMoveKey(KeyEventArgs e, Worksheet sheet, Action moveAction)
+			{
+				e.SuppressKeyPress = true;
+				sheet.EndEdit(Text);
+				moveAction();
+			}
 
-            protected override bool ProcessCmdKey(ref Message msg, System.Windows.Forms.Keys keyData)
+			protected override bool ProcessCmdKey(ref Message msg, System.Windows.Forms.Keys keyData)
 			{
 				var sheet = owner.currentWorksheet;
 
@@ -1221,10 +1221,10 @@ namespace unvell.ReoGrid
 				{
 					int inputChar = m.WParam.ToInt32();
 
-					if (inputChar != 8			// backspace
+					if (inputChar != 8      // backspace
 						&& inputChar != 13     // enter
 						&& inputChar != 27     // escape
-						//&& inputChar != '\t'   // tab
+																	 //&& inputChar != '\t'   // tab
 						)
 					{
 						inputChar = this.owner.currentWorksheet.RaiseCellEditCharInputed(m.WParam.ToInt32());
@@ -1278,10 +1278,10 @@ namespace unvell.ReoGrid
 		{
 			if (Toolkit.IsKeyDown(Win32.VKey.VK_MENU)
 				|| Toolkit.IsKeyDown(Win32.VKey.VK_CONTROL)
-				|| charCode == 8			// backspace
-				|| charCode == 13			// enter
-				|| charCode == 27			// escape
-				|| charCode == '\t'		// tab
+				|| charCode == 8      // backspace
+				|| charCode == 13     // enter
+				|| charCode == 27     // escape
+				|| charCode == '\t'   // tab
 				)
 			{
 				return false;
@@ -1315,21 +1315,21 @@ namespace unvell.ReoGrid
 				// Chinese and Japanese IME will send this message
 				// before start to accept user's input
 				if (m.Msg == (int)Win32.WMessages.WM_IME_STARTCOMPOSITION)
+			{
+				this.currentWorksheet.StartEdit(string.Empty);
+			}
+			else if (m.Msg == (int)Win32.WMessages.WM_MOUSEHWHEEL)
+			{
+				if (this.currentWorksheet.ViewportController is IScrollableViewportController)
 				{
-					this.currentWorksheet.StartEdit(string.Empty);
-				}
-				else if (m.Msg == (int)Win32.WMessages.WM_MOUSEHWHEEL)
-				{
-					if (this.currentWorksheet.ViewportController is IScrollableViewportController)
-					{
-						var svc = this.currentWorksheet.ViewportController as IScrollableViewportController;
+					var svc = this.currentWorksheet.ViewportController as IScrollableViewportController;
 
-						// get an overflow error by my logitech mouse t620
-						// fixed by (int)(long) cast
-						int delta = (short)((long)m.WParam >> 16) / 10; // get delta
-						svc.ScrollViews(ScrollDirection.Horizontal, -delta, 0);
-					}
+					// get an overflow error by my logitech mouse t620
+					// fixed by (int)(long) cast
+					int delta = (short)((long)m.WParam >> 16) / 10; // get delta
+					svc.ScrollViews(ScrollDirection.Horizontal, -delta, 0);
 				}
+			}
 
 			base.WndProc(ref m);
 		}


### PR DESCRIPTION
## Fixes

Fixes the bug that worksheet automatically scrolls to the last cell after following operations.

- Delete rows or columns by select entire row
- Drag rows or columns to other position
