### PR TITLE
Cell width and height on High DPI device

### DIFF
--- a/ReoGrid/Core/Worksheet/InitReset.cs
+++ b/ReoGrid/Core/Worksheet/InitReset.cs
@@ -39,6 +39,7 @@ using VBorderArray = unvell.ReoGrid.Data.ReoGridVBorderArray;
 #endif // ANDROID
 
 using unvell.ReoGrid.Main;
+using unvell.ReoGrid.Utility;
 
 namespace unvell.ReoGrid
 {
@@ -56,6 +57,12 @@ namespace unvell.ReoGrid
 			Stopwatch sw = Stopwatch.StartNew();
 			Debug.WriteLine("start creating worksheet...");
 #endif // DEBUG
+
+			this.colHeaderHeight = MeasureToolkit.ScaleByDPI(colHeaderHeight);
+			this.rowHeaderWidth = MeasureToolkit.ScaleByDPI(rowHeaderWidth);
+
+			this.defaultRowHeight = MeasureToolkit.ScaleByDPI(defaultRowHeight);
+			this.defaultColumnWidth = MeasureToolkit.ScaleByDPI(defaultColumnWidth);
 
 			this.SuspendUIUpdates();
 

--- a/ReoGrid/IO/ExcelReader.cs
+++ b/ReoGrid/IO/ExcelReader.cs
@@ -171,7 +171,7 @@ namespace unvell.ReoGrid.IO.OpenXML
 
 			var sheet = doc.LoadRelationResourceById<Schema.Worksheet>(doc.Workbook, sheetIndex.resId);
 
-			const float fixedCharWidth = 7.0f; //ResourcePoolManager.Instance.GetFont("Arial", 10f, System.Drawing.FontStyle.Regular).SizeInPoints;
+			float fixedCharWidth = MeasureToolkit.ScaleByDPI(7.0f); //ResourcePoolManager.Instance.GetFont("Arial", 10f, System.Drawing.FontStyle.Regular).SizeInPoints;
 
 			#region SheetView
 			var sheetView = sheet.sheetViews.FirstOrDefault() as SheetView;

--- a/ReoGrid/Utility/MeasureToolkit.cs
+++ b/ReoGrid/Utility/MeasureToolkit.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using unvell.ReoGrid.Rendering;
 
 #if WINFORM || ANDROID
 using RGFloat = System.Single;
@@ -74,6 +75,17 @@ namespace unvell.ReoGrid.Utility
 		public static int PixelToEMU(RGFloat pixel, RGFloat dpi)
 		{
 			return (int)(pixel * _emi_in_inch / dpi);
+		}
+
+		public static T ScaleByDPI<T>(T val)
+		{
+			double dpi = PlatformUtility.GetDPI();
+			double scale = dpi / 96.0;
+
+			double dVal = (double)Convert.ChangeType(val, typeof(double));
+
+			T result = (T)Convert.ChangeType(dVal * scale, typeof(T));
+			return result;
 		}
 	}
 


### PR DESCRIPTION
fix this [issue](https://github.com/unvell/ReoGrid/issues/446)

Add ScaleByDPI to unvell.ReoGrid.Utility.MeasureToolkit. 

Scale cell's width and height in Worksheet.InitGrid.

Scale fixedCharWidth in ExcelReader.LoadWorksheet.