### PR TITLE
null reference exception fixed

### DIFF
--- a/ReoGrid/IO/ExcelReader.cs
+++ b/ReoGrid/IO/ExcelReader.cs
@@ -312,8 +312,7 @@ namespace unvell.ReoGrid.IO.OpenXML
 			// data
 			SharedStrings sharedStringTable = doc.ReadSharedStringTable();
 
-			var defaultFont = fonts.list.ElementAtOrDefault(0) as Schema.Font;
-			if (defaultFont != null)
+			if (fonts?.list != null && fonts.list.ElementAtOrDefault(0) is Font defaultFont)
 			{
 				SetStyleFont(doc, rgSheet.RootStyle, defaultFont);
 			}


### PR DESCRIPTION
In some cases, the fonts or fonts.list may be empty, which can trigger a null reference exception.