### PR TITLE
FIX: #554: Excel cell line breaks not retained when pasted into ReoGrid 

### DIFF
--- a/DemoWPF/MainWindow.xaml.cs
+++ b/DemoWPF/MainWindow.xaml.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Shapes;
 using unvell.ReoGrid.CellTypes;
@@ -279,16 +282,196 @@ namespace unvell.ReoGrid.WPFDemo
 
 			// information cell
 			worksheet.SetRangeBorders(19, 0, 1, 10, BorderPositions.Top, RangeBorderStyle.GraySolid);
-		}
+
+      // dropdown cell
+      worksheet["B18"] = "Dropdown ListView:";
+      worksheet["D18"] = "Choose...";
+      worksheet["D18"] = new ListViewDropdownCell();
+      worksheet.Ranges["D18"].BorderOutside = RangeBorderStyle.GraySolid;
+    }
 
 		private void ShowText(Worksheet sheet, string text)
 		{
 			sheet[19, 0] = text;
 		}
-		#endregion // Demo Sheet 3 : Built-in Cell Types
 
-		#region Menu - File
-		private void File_New_Click(object sender, RoutedEventArgs e)
+
+    class ListViewDropdownCell : DropdownCell
+    {
+      private readonly ListView listView;
+
+      public ListViewDropdownCell()
+      {
+        listView = new ListView
+        {
+          BorderThickness = new Thickness(0),
+          SelectionMode = SelectionMode.Single,
+          View = new GridView()
+        };
+
+        this.DropdownControl = listView;
+
+        var gridView = (GridView)listView.View;
+        gridView.Columns.Add(new GridViewColumn
+        {
+          Header = "Name",
+          Width = 120,
+          DisplayMemberBinding = new System.Windows.Data.Binding(nameof(ListViewItemData.Text))
+        });
+        gridView.Columns.Add(new GridViewColumn
+        {
+          Header = "Description",
+          Width = 120,
+          DisplayMemberBinding = new System.Windows.Data.Binding(nameof(ListViewItemData.SubText))
+        });
+
+        // Create data items
+        var items = new List<ListViewItemData>
+        {
+            new ListViewItemData { Group = "A", Text = "Apple", SubText = "Red fruit" },
+            new ListViewItemData { Group = "A", Text = "Banana", SubText = "Yellow fruit" },
+            new ListViewItemData { Group = "B", Text = "Watermelon", SubText = "Green fruit" },
+            new ListViewItemData { Group = "B", Text = "Grape", SubText = "Purple fruit" }
+        };
+
+        listView.ItemsSource = items;
+        this.MinimumDropdownWidth = 300;
+
+        listView.PreviewMouseDoubleClick += ListView_MouseDoubleClick;
+        listView.PreviewKeyDown += ListView_PreviewKeyDown;
+      }
+
+      private void ListView_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+      {
+        var listView = sender as ListView;
+        var depObj = e.OriginalSource as DependencyObject;
+        while (depObj != null && !(depObj is ListViewItem))
+          depObj = VisualTreeHelper.GetParent(depObj);
+
+        if (depObj is ListViewItem listViewItem)
+        {
+          listView.SelectedItem = listView.ItemContainerGenerator.ItemFromContainer(listViewItem);
+        }
+
+        CommitSelection();
+      }
+
+      private void ListView_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+      {
+        var listView = sender as ListView;
+
+        if (e.Key == System.Windows.Input.Key.Enter)
+        {
+          CommitSelection();
+          e.Handled = true;
+        }
+        else if (e.Key == System.Windows.Input.Key.Escape)
+        {
+          PullUp();
+          e.Handled = true;
+        }
+        else if (e.Key == System.Windows.Input.Key.Up || e.Key == System.Windows.Input.Key.Down)
+        {
+          // Handle up/down key selection 
+          int currentIndex = listView.SelectedIndex;
+          int itemCount = listView.Items.Count;
+
+          if (itemCount > 0)
+          {
+            if (e.Key == System.Windows.Input.Key.Up)
+            {
+              // Up key: select previous item
+              if (currentIndex > 0)
+              {
+                listView.SelectedIndex = currentIndex - 1;
+                var item = listView.ItemContainerGenerator.ContainerFromIndex(currentIndex - 1) as ListViewItem;
+                item?.Focus();
+              }
+              else
+              {
+                // If on first item, cycle to last item 
+                listView.SelectedIndex = itemCount - 1;
+                var item = listView.ItemContainerGenerator.ContainerFromIndex(itemCount - 1) as ListViewItem;
+                item?.Focus();
+              }
+            }
+            else if (e.Key == System.Windows.Input.Key.Down)
+            {
+              // Down key: select next item 
+              if (currentIndex < itemCount - 1)
+              {
+                listView.SelectedIndex = currentIndex + 1;
+                var item = listView.ItemContainerGenerator.ContainerFromIndex(currentIndex + 1) as ListViewItem;
+                item?.Focus();
+              }
+              else
+              {
+                // If on last item, cycle to first item
+                listView.SelectedIndex = 0;
+                var item = listView.ItemContainerGenerator.ContainerFromIndex(0) as ListViewItem;
+                item?.Focus();
+              }
+            }
+
+            // Ensure selected item is visible
+            if (listView.SelectedItem != null)
+            {
+              listView.ScrollIntoView(listView.SelectedItem);
+            }
+
+            e.Handled = true;
+          }
+        }
+        else if (e.Key == System.Windows.Input.Key.Tab)
+        {
+          // Handle Tab key 
+          CommitSelection();
+          e.Handled = true;
+        }
+      }
+
+      protected override void OnDropdownControlLostFocus()
+      {
+        PullUp();
+      }
+
+      public override void PushDown()
+      {
+        base.PushDown();
+
+        // When dropdown panel opens, automatically select the item matching current cell content
+        if (this.Cell?.Data is string text && listView.ItemsSource is IEnumerable<ListViewItemData> items)
+        {
+          var itemToSelect = items.FirstOrDefault(i => i.Text == text);
+          if (itemToSelect != null)
+          {
+            listView.SelectedItem = itemToSelect;
+            listView.ScrollIntoView(itemToSelect);
+          }
+        }
+      }
+
+      private void CommitSelection()
+      {
+        if (listView.SelectedItem is ListViewItemData selectedItem)
+        {
+          this.Cell.Data = selectedItem.Text;
+          PullUp();
+        }
+      }
+
+      // Data item class
+      private class ListViewItemData
+      {
+        public string Group { get; set; }
+        public string Text { get; set; }
+        public string SubText { get; set; }
+      }
+    }
+    #endregion // Demo Sheet 3 : Built-in Cell Types
+
+    #region Menu - File
+    private void File_New_Click(object sender, RoutedEventArgs e)
 		{
 			grid.Reset();
 		}

--- a/DemoWPF/MainWindow.xaml.cs
+++ b/DemoWPF/MainWindow.xaml.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Shapes;
 using unvell.ReoGrid.CellTypes;
@@ -279,16 +282,196 @@ namespace unvell.ReoGrid.WPFDemo
 
 			// information cell
 			worksheet.SetRangeBorders(19, 0, 1, 10, BorderPositions.Top, RangeBorderStyle.GraySolid);
-		}
+
+      // dropdown cell
+      worksheet["B18"] = "Dropdown ListView:";
+      worksheet["D18"] = "Choose...";
+      worksheet["D18"] = new ListViewDropdownCell();
+      worksheet.Ranges["D18"].BorderOutside = RangeBorderStyle.GraySolid;
+    }
 
 		private void ShowText(Worksheet sheet, string text)
 		{
 			sheet[19, 0] = text;
 		}
-		#endregion // Demo Sheet 3 : Built-in Cell Types
 
-		#region Menu - File
-		private void File_New_Click(object sender, RoutedEventArgs e)
+
+    class ListViewDropdownCell : DropdownCell
+    {
+      private readonly ListView listView;
+
+      public ListViewDropdownCell()
+      {
+        listView = new ListView
+        {
+          BorderThickness = new Thickness(0),
+          SelectionMode = SelectionMode.Single,
+          View = new GridView()
+        };
+
+        this.DropdownControl = listView;
+
+        var gridView = (GridView)listView.View;
+        gridView.Columns.Add(new GridViewColumn
+        {
+          Header = "Name",
+          Width = 120,
+          DisplayMemberBinding = new System.Windows.Data.Binding(nameof(ListViewItemData.Text))
+        });
+        gridView.Columns.Add(new GridViewColumn
+        {
+          Header = "Description",
+          Width = 120,
+          DisplayMemberBinding = new System.Windows.Data.Binding(nameof(ListViewItemData.SubText))
+        });
+
+        // Create data items
+        var items = new List<ListViewItemData>
+        {
+            new ListViewItemData { Group = "A", Text = "Apple", SubText = "Red fruit" },      // 原注释: "苹果", "红色水果"
+            new ListViewItemData { Group = "A", Text = "Banana", SubText = "Yellow fruit" },  // 原注释: "香蕉", "黄色水果"
+            new ListViewItemData { Group = "B", Text = "Watermelon", SubText = "Green fruit" }, // 原注释: "西瓜", "绿色水果"
+            new ListViewItemData { Group = "B", Text = "Grape", SubText = "Purple fruit" }     // 原注释: "葡萄", "紫色水果"
+        };
+
+        listView.ItemsSource = items;
+        this.MinimumDropdownWidth = 300;
+
+        listView.PreviewMouseDoubleClick += ListView_MouseDoubleClick;
+        listView.PreviewKeyDown += ListView_PreviewKeyDown;
+      }
+
+      private void ListView_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+      {
+        var listView = sender as ListView;
+        var depObj = e.OriginalSource as DependencyObject;
+        while (depObj != null && !(depObj is ListViewItem))
+          depObj = VisualTreeHelper.GetParent(depObj);
+
+        if (depObj is ListViewItem listViewItem)
+        {
+          listView.SelectedItem = listView.ItemContainerGenerator.ItemFromContainer(listViewItem);
+        }
+
+        CommitSelection();
+      }
+
+      private void ListView_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+      {
+        var listView = sender as ListView;
+
+        if (e.Key == System.Windows.Input.Key.Enter)
+        {
+          CommitSelection();
+          e.Handled = true;
+        }
+        else if (e.Key == System.Windows.Input.Key.Escape)
+        {
+          PullUp();
+          e.Handled = true;
+        }
+        else if (e.Key == System.Windows.Input.Key.Up || e.Key == System.Windows.Input.Key.Down)
+        {
+          // Handle up/down key selection 
+          int currentIndex = listView.SelectedIndex;
+          int itemCount = listView.Items.Count;
+
+          if (itemCount > 0)
+          {
+            if (e.Key == System.Windows.Input.Key.Up)
+            {
+              // Up key: select previous item
+              if (currentIndex > 0)
+              {
+                listView.SelectedIndex = currentIndex - 1;
+                var item = listView.ItemContainerGenerator.ContainerFromIndex(currentIndex - 1) as ListViewItem;
+                item?.Focus();
+              }
+              else
+              {
+                // If on first item, cycle to last item 
+                listView.SelectedIndex = itemCount - 1;
+                var item = listView.ItemContainerGenerator.ContainerFromIndex(itemCount - 1) as ListViewItem;
+                item?.Focus();
+              }
+            }
+            else if (e.Key == System.Windows.Input.Key.Down)
+            {
+              // Down key: select next item 
+              if (currentIndex < itemCount - 1)
+              {
+                listView.SelectedIndex = currentIndex + 1;
+                var item = listView.ItemContainerGenerator.ContainerFromIndex(currentIndex + 1) as ListViewItem;
+                item?.Focus();
+              }
+              else
+              {
+                // If on last item, cycle to first item
+                listView.SelectedIndex = 0;
+                var item = listView.ItemContainerGenerator.ContainerFromIndex(0) as ListViewItem;
+                item?.Focus();
+              }
+            }
+
+            // Ensure selected item is visible
+            if (listView.SelectedItem != null)
+            {
+              listView.ScrollIntoView(listView.SelectedItem);
+            }
+
+            e.Handled = true;
+          }
+        }
+        else if (e.Key == System.Windows.Input.Key.Tab)
+        {
+          // Handle Tab key 
+          CommitSelection();
+          e.Handled = true;
+        }
+      }
+
+      protected override void OnDropdownControlLostFocus()
+      {
+        PullUp();
+      }
+
+      public override void PushDown()
+      {
+        base.PushDown();
+
+        // When dropdown panel opens, automatically select the item matching current cell content
+        if (this.Cell?.Data is string text && listView.ItemsSource is IEnumerable<ListViewItemData> items)
+        {
+          var itemToSelect = items.FirstOrDefault(i => i.Text == text);
+          if (itemToSelect != null)
+          {
+            listView.SelectedItem = itemToSelect;
+            listView.ScrollIntoView(itemToSelect);
+          }
+        }
+      }
+
+      private void CommitSelection()
+      {
+        if (listView.SelectedItem is ListViewItemData selectedItem)
+        {
+          this.Cell.Data = selectedItem.Text;
+          PullUp();
+        }
+      }
+
+      // Data item class
+      private class ListViewItemData
+      {
+        public string Group { get; set; }
+        public string Text { get; set; }
+        public string SubText { get; set; }
+      }
+    }
+    #endregion // Demo Sheet 3 : Built-in Cell Types
+
+    #region Menu - File
+    private void File_New_Click(object sender, RoutedEventArgs e)
 		{
 			grid.Reset();
 		}

--- a/ReoGrid/CellTypes/DropdownCell.cs
+++ b/ReoGrid/CellTypes/DropdownCell.cs
@@ -34,9 +34,6 @@ using unvell.ReoGrid.Events;
 using unvell.ReoGrid.Graphics;
 using unvell.ReoGrid.Rendering;
 using unvell.ReoGrid.Interaction;
-using Size = unvell.ReoGrid.Graphics.Size;
-using System.Windows;
-
 
 namespace unvell.ReoGrid.CellTypes
 {
@@ -403,11 +400,13 @@ namespace unvell.ReoGrid.CellTypes
 			}
 		}
 
-    #region Dropdown Window
-    /// <summary>
-    /// Prepresents dropdown window for dropdown cells.
-    /// </summary>
-    protected class DropdownWindow : ToolStripDropDown
+		#region Dropdown Window
+
+		/// <summary>
+		/// Prepresents dropdown window for dropdown cells.
+		/// </summary>
+#if WINFORM
+		protected class DropdownWindow : ToolStripDropDown
 		{
 			private DropdownCell owner;
 			private ToolStripControlHost controlHost;
@@ -464,297 +463,26 @@ namespace unvell.ReoGrid.CellTypes
 				}
 			}
 		}
-
-    #endregion // Dropdown Window
-  }
 #elif WPF
-  /// <summary>
-  /// Abstract base class for WPF dropdown cells
-  /// </summary>
-  public abstract class DropdownCell : CellBody
-  {
-    private DropdownWindow dropdownPanel;
+		protected class DropdownWindow : System.Windows.Controls.Primitives.Popup
+		{
+			private DropdownCell owner;
 
-    /// <summary>
-    /// Get dropdown panel
-    /// </summary>
-    protected DropdownWindow DropdownPanel => dropdownPanel;
+			public DropdownWindow(DropdownCell owner)
+			{
+				this.owner = owner;
+			}
 
-    private bool pullDownOnClick = true;
-    public virtual bool PullDownOnClick
-    {
-      get => pullDownOnClick;
-      set => pullDownOnClick = value;
-    }
-
-    private Size dropdownButtonSize = new Size(20, 20);
-    public virtual Size DropdownButtonSize
-    {
-      get => dropdownButtonSize;
-      set => dropdownButtonSize = value;
-    }
-
-    private bool dropdownButtonAutoHeight = true;
-    public virtual bool DropdownButtonAutoHeight
-    {
-      get => dropdownButtonAutoHeight;
-      set { dropdownButtonAutoHeight = value; OnBoundsChanged(); }
-    }
-
-    private Rectangle dropdownButtonRect = new Rectangle(0, 0, 20, 20);
-    protected Rectangle DropdownButtonRect => dropdownButtonRect;
-
-    private FrameworkElement dropdownControl;
-    public virtual FrameworkElement DropdownControl
-    {
-      get => dropdownControl;
-      set => dropdownControl = value;
-    }
-
-    protected virtual void OnDropdownControlLostFocus()
-    {
-      PullUp();
-    }
-
-    private bool isDropdown;
-    public bool IsDropdown
-    {
-      get => isDropdown;
-      set
-      {
-        if (isDropdown != value)
-        {
-          if (value) PushDown();
-          else PullUp();
-        }
-      }
-    }
-
-    public DropdownCell() { }
-
-    public override void OnBoundsChanged()
-    {
-      dropdownButtonRect.Width = dropdownButtonSize.Width;
-      dropdownButtonRect.Width = Math.Max(3, Math.Min(dropdownButtonRect.Width, Bounds.Width));
-
-      dropdownButtonRect.Height = dropdownButtonAutoHeight
-          ? Bounds.Height - 1
-          : Math.Min(dropdownButtonSize.Height, Bounds.Height - 1);
-
-      dropdownButtonRect.X = Bounds.Right - dropdownButtonRect.Width;
-
-      ReoGridVerAlign valign = ReoGridVerAlign.General;
-      if (Cell?.InnerStyle?.HasStyle(PlainStyleFlag.VerticalAlign) == true)
-        valign = Cell.InnerStyle.VAlign;
-
-      switch (valign)
-      {
-        case ReoGridVerAlign.Top:
-          dropdownButtonRect.Y = 1;
-          break;
-        case ReoGridVerAlign.General:
-        case ReoGridVerAlign.Bottom:
-          dropdownButtonRect.Y = Bounds.Bottom - dropdownButtonRect.Height;
-          break;
-        case ReoGridVerAlign.Middle:
-          dropdownButtonRect.Y = Bounds.Top + (Bounds.Height - dropdownButtonRect.Height) / 2 + 1;
-          break;
-      }
-    }
-
-    public override void OnPaint(CellDrawingContext dc)
-    {
-      base.OnPaint(dc);
-      OnPaintDropdownButton(dc, dropdownButtonRect);
-    }
-
-    protected virtual void OnPaintDropdownButton(CellDrawingContext dc, Rectangle buttonRect)
-    {
-      if (Cell == null) return;
-
-      var backgroundBrush = new System.Windows.Media.SolidColorBrush(
-          Cell.IsReadOnly ? System.Windows.SystemColors.ControlBrush.Color :
-          (isDropdown ? System.Windows.SystemColors.ControlDarkBrush.Color : System.Windows.SystemColors.ControlBrush.Color));
-
-      var borderBrush = new System.Windows.Media.SolidColorBrush(System.Windows.SystemColors.ControlDarkBrush.Color);
-      var arrowBrush = new System.Windows.Media.SolidColorBrush(
-          Cell.IsReadOnly ? System.Windows.SystemColors.GrayTextBrush.Color : System.Windows.SystemColors.ControlTextBrush.Color);
-
-      var dv = new System.Windows.Media.DrawingVisual();
-      using (var dw = dv.RenderOpen())
-      {
-        dw.DrawRectangle(backgroundBrush, new System.Windows.Media.Pen(borderBrush, 1), (System.Windows.Rect)buttonRect);
-
-        var arrowRect = new System.Windows.Rect(
-            buttonRect.X + buttonRect.Width / 2 - 4,
-            buttonRect.Y + buttonRect.Height / 2 - 2,
-            8, 4);
-
-        var points = new[]
-        {
-                new System.Windows.Point(arrowRect.Left, arrowRect.Top),
-                new System.Windows.Point(arrowRect.Right, arrowRect.Top),
-                new System.Windows.Point(arrowRect.Left + arrowRect.Width / 2, arrowRect.Bottom)
-            };
-
-        dw.DrawGeometry(arrowBrush, null,
-            new System.Windows.Media.PathGeometry(new[]
-            {
-                    new System.Windows.Media.PathFigure(points[0],
-                        new[]
-                        {
-                            new System.Windows.Media.LineSegment(points[1], true),
-                            new System.Windows.Media.LineSegment(points[2], true)
-                        }, true)
-            }));
-      }
-      dc.Graphics.PlatformGraphics.DrawDrawing(dv.Drawing);
-    }
-
-    public override bool OnMouseDown(CellMouseEventArgs e)
-    {
-      if (PullDownOnClick || dropdownButtonRect.Contains(e.RelativePosition))
-      {
-        if (isDropdown) PullUp();
-        else PushDown();
-        return true;
-      }
-      return false;
-    }
-
-    public override bool OnMouseMove(CellMouseEventArgs e)
-    {
-      if (dropdownButtonRect.Contains(e.RelativePosition))
-      {
-        e.CursorStyle = CursorStyle.Hand;
-        return true;
-      }
-      return false;
-    }
-
-    public override void OnLostFocus() => PullUp();
-
-    public event EventHandler DropdownOpened;
-    public event EventHandler DropdownClosed;
-
-    public override bool OnStartEdit()
-    {
-      PushDown();
-      return false;
-    }
-
-    private Worksheet sheet;
-
-    public virtual void PushDown()
-    {
-      if (Cell == null || Cell.Worksheet == null) return;
-      if (Cell.IsReadOnly && DisableWhenCellReadonly) return;
-
-      sheet = Cell.Worksheet;
-
-      if (sheet != null && DropdownControl != null &&
-          Views.CellsViewport.TryGetCellPositionToControl(sheet.ViewportController.FocusView, Cell.InternalPos, out var p))
-      {
-        if (dropdownPanel == null)
-        {
-          dropdownPanel = new DropdownWindow(this);
-          dropdownPanel.Closed += DropdownPanel_Closed;
-        }
-
-        dropdownPanel.Width = Math.Max(Bounds.Width, MinimumDropdownWidth);
-        dropdownPanel.Height = DropdownPanelHeight;
-
-        dropdownPanel.Show(sheet.workbook.ControlInstance, new System.Windows.Point(p.X, p.Y + Bounds.Height));
-        DropdownControl.Focus();
-        isDropdown = true;
-      }
-      DropdownOpened?.Invoke(this, null);
-    }
-
-    private void DropdownPanel_Closed(object sender, EventArgs e) => OnDropdownControlLostFocus();
-
-    private int dropdownHeight = 200;
-    public virtual int DropdownPanelHeight
-    {
-      get => dropdownHeight;
-      set => dropdownHeight = value;
-    }
-
-    private int minimumDropdownWidth = 120;
-    public virtual int MinimumDropdownWidth
-    {
-      get => minimumDropdownWidth;
-      set => minimumDropdownWidth = value;
-    }
-
-    public virtual void PullUp()
-    {
-      if (dropdownPanel != null)
-      {
-        dropdownPanel.Hide();
-        isDropdown = false;
-        sheet?.RequestInvalidate();
-      }
-      DropdownClosed?.Invoke(this, null);
-    }
-
-    #region Dropdown Window
-    /// <summary>
-    /// WPF dropdown popup window
-    /// </summary>
-    protected class DropdownWindow : System.Windows.Controls.Primitives.Popup
-    {
-      private DropdownCell owner;
-      private System.Windows.Controls.Border border;
-      private System.Windows.UIElement controlHost;
-
-      public DropdownWindow(DropdownCell owner)
-      {
-        this.owner = owner;
-        border = new System.Windows.Controls.Border
-        {
-          BorderBrush = System.Windows.Media.Brushes.Gray,
-          BorderThickness = new System.Windows.Thickness(1),
-          Background = System.Windows.Media.Brushes.White
-        };
-
-        controlHost = owner.DropdownControl as System.Windows.UIElement;
-        if (controlHost != null)
-          border.Child = controlHost;
-
-        Child = border;
-        Opened += DropdownWindow_Opened;
-      }
-
-      private void DropdownWindow_Opened(object sender, EventArgs e)
-      {
-        if (owner.DropdownControl != null)
-          System.Windows.Input.Keyboard.Focus(controlHost);
-      }
-
-      public new void Show(System.Windows.UIElement parent, System.Windows.Point point)
-      {
-        Placement = System.Windows.Controls.Primitives.PlacementMode.Absolute;
-        HorizontalOffset = point.X;
-        VerticalOffset = point.Y;
-        IsOpen = true;
-      }
-
-      public void Hide()
-      {
-        IsOpen = false;
-        owner.sheet?.EndEdit(EndEditReason.Cancel);
-      }
-
-      protected override void OnPreviewMouseDown(System.Windows.Input.MouseButtonEventArgs e)
-      {
-        base.OnPreviewMouseDown(e);
-        e.Handled = true;
-      }
-
-      public bool DisableWhenCellReadonly { get; set; } = true;
-    }
-    #endregion
-  }
+			public void Hide()
+			{
+				this.IsOpen = false;
+			}
+		}
 #endif // WPF
+
+		#endregion // Dropdown Window
+
+	}
+
+#endif // WINFORM
 }

--- a/ReoGrid/Utility/RGUtility.cs
+++ b/ReoGrid/Utility/RGUtility.cs
@@ -17,7 +17,6 @@
  ****************************************************************************/
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -116,109 +115,84 @@ namespace unvell.ReoGrid
 			return NameRegex.IsMatch(name);
 		}
 
-    /// <summary>
-    /// Parse tabbed string into regular array, handling quoted strings properly
-    /// </summary>
-    /// <param name="str">string to be parsed</param>
-    /// <returns>parsed regular array</returns>
-    public static object[,] ParseTabbedString(string str)
-    {
-      var lines = new List<string>();
-      bool inQuote = false;
-      int start = 0;
+		/// <summary>
+		/// Parse tabbed string into regular array
+		/// </summary>
+		/// <param name="str">string to be parsed</param>
+		/// <returns>parsed regular array</returns>
+		public static object[,] ParseTabbedString(string str)
+		{
+			int rows = 0, cols = 0;
+			
+			string[] lines = str.Split(new string[] { "\n" }, StringSplitOptions.None);
 
-      for (int i = 0; i < str.Length; i++)
-      {
-        char c = str[i];
+			int len = lines.Length;
+			
+			while (string.IsNullOrEmpty(lines[len - 1]))
+			{
+				len--;
+			}
 
-        if (c == '"')
-        {
-          // Check for escaped quotes
-          if (i + 1 < str.Length && str[i + 1] == '"')
-          {
-            i++; // Skip next quote as it's escaped
-          }
-          else
-          {
-            inQuote = !inQuote; // Toggle quote state
-          }
-        }
-        else if (c == '\n' && !inQuote)
-        {
-          // Only split on newlines outside of quotes
-          lines.Add(str.Substring(start, i - start));
-          start = i + 1;
-        }
-      }
+			for (int r = 0; r < len; r++)
+			{
+				string line = lines[r];
+				
+				if (line.EndsWith("\n")) line = line.Substring(0, line.Length - 1);
+				if (line.EndsWith("\r")) line = line.Substring(0, line.Length - 1);
 
-      // Add the last line if there's any content left
-      if (start < str.Length)
-      {
-        lines.Add(str.Substring(start));
-      }
+				string[] tabs = line.Split('\t');
+				cols = Math.Max(cols, tabs.Length);
+				rows++;
+			}
 
-      int rows = lines.Count;
-      int cols = 0;
+			object[,] arr = new object[rows, cols];
 
-      // Determine maximum number of columns
-      for (int r = 0; r < lines.Count; r++)
-      {
-        string line = lines[r];
-        if (line.EndsWith("\n")) line = line.Substring(0, line.Length - 1);
-        if (line.EndsWith("\r")) line = line.Substring(0, line.Length - 1);
+			for (int r = 0; r < lines.Length; r++)
+			{
+				string line = lines[r];
+			
+				if (line.EndsWith("\n")) line = line.Substring(0, line.Length - 1);
+				if (line.EndsWith("\r")) line = line.Substring(0, line.Length - 1);
 
-        string[] tabs = line.Split('\t');
-        cols = Math.Max(cols, tabs.Length);
-      }
+				if (line.Length > 0)
+				{
+					string[] tabs = line.Split('\t');
+					cols = Math.Max(cols, tabs.Length);
 
-      object[,] arr = new object[rows, cols];
+					for (int c = 0; c < tabs.Length; c++)
+					{
+						string text = tabs[c];
 
-      for (int r = 0; r < lines.Count; r++)
-      {
-        string line = lines[r];
-        if (line.EndsWith("\n")) line = line.Substring(0, line.Length - 1);
-        if (line.EndsWith("\r")) line = line.Substring(0, line.Length - 1);
+						if (text.StartsWith("\"") && text.EndsWith("\""))
+						{
+							text = text.Substring(1, text.Length - 2);
+						}
 
-        if (line.Length > 0)
-        {
-          string[] tabs = line.Split('\t');
+						arr[r, c] = text;
+					}
+					rows++;
+				}
+			}
 
-          for (int c = 0; c < tabs.Length; c++)
-          {
-            string text = tabs[c];
+			return arr;
+		}
 
-            // Handle quoted strings
-            if (text.StartsWith("\"") && text.EndsWith("\""))
-            {
-              text = text.Substring(1, text.Length - 2);
-              // Unescape double quotes
-              text = text.Replace("\"\"", "\"");
-            }
-
-            arr[r, c] = text;
-          }
-        }
-      }
-
-      return arr;
-    }
-
-    #region ToAddress
-    /// <summary>
-    /// Convert position or range into address string
-    /// </summary>
-    /// <param name="row">Zero-based index number of row</param>
-    /// <param name="col">Zero-based index number of column</param>
-    /// <param name="absNum">Determine that which R1C1 format should be used.<br/>
-    /// <ul>
-    /// <li>1: [Absolute Row][Absolute Col] R1C1</li>
-    /// <li>2: [Absolute Row][Relative Col] R1C[1]</li>
-    /// <li>3: [Relative Row][Absolute Col] R[1]C1</li>
-    /// <li>4: [Relative Row][Relative Col] R[1]C[1]</li>
-    /// </ul>
-    /// </param>
-    /// <returns>position or range in address string</returns>
-    public static string ToAddress(int row, int col, int absNum)
+		#region ToAddress
+		/// <summary>
+		/// Convert position or range into address string
+		/// </summary>
+		/// <param name="row">Zero-based index number of row</param>
+		/// <param name="col">Zero-based index number of column</param>
+		/// <param name="absNum">Determine that which R1C1 format should be used.<br/>
+		/// <ul>
+		/// <li>1: [Absolute Row][Absolute Col] R1C1</li>
+		/// <li>2: [Absolute Row][Relative Col] R1C[1]</li>
+		/// <li>3: [Relative Row][Absolute Col] R[1]C1</li>
+		/// <li>4: [Relative Row][Relative Col] R[1]C[1]</li>
+		/// </ul>
+		/// </param>
+		/// <returns>position or range in address string</returns>
+		public static string ToAddress(int row, int col, int absNum)
 		{
 			return ToAddress(row, col, 1, 1, absNum, false);
 		}


### PR DESCRIPTION
Problem Description:

1. The content in cell A1 of Excel contains text with line breaks.
2. Copy the cell range A1:B2.
3. When pasting into this ReoGrid, the line breaks in A1 cause the data to become 3 rows and 2 columns.